### PR TITLE
chore: add property resolver for nested key translations.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,9 +17,10 @@ class MyApp extends StatelessWidget {
           GlobalWidgetsLocalizations.delegate,
           //app-specific localization
           EasylocaLizationDelegate(
-              locale: data.locale ?? Locale('en','US'), path: 'resources/langs'),
+              locale: data.locale ?? Locale('en', 'US'),
+              path: 'resources/langs'),
         ],
-        supportedLocales: [Locale('en','US'), Locale('ar','DZ')],
+        supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')],
         locale: data.locale,
         theme: ThemeData(
           primarySwatch: Colors.blue,
@@ -40,12 +41,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
- int counter = 0;
+  int counter = 0;
   incrementCounter() {
     setState(() {
       counter++;
     });
   }
+
   @override
   Widget build(BuildContext context) {
     var data = EasyLocalizationProvider.of(context).data;
@@ -85,18 +87,25 @@ class _MyHomePageState extends State<MyHomePage> {
           child: new Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              new Text(AppLocalizations.of(context).tr('msg',args: ['aissat','Flutter'])),
-              new Text(AppLocalizations.of(context).plural('clicked',counter)),
+              new Text(AppLocalizations.of(context)
+                  .tr('msg', args: ['aissat', 'Flutter'])),
+              new Text(AppLocalizations.of(context).plural('clicked', counter)),
               new FlatButton(
-                  onPressed: () async {
-                    incrementCounter();
-                  },
-                  child: new Text(AppLocalizations.of(context).tr('clickMe')),)
-            
+                onPressed: () async {
+                  incrementCounter();
+                },
+                child: new Text(AppLocalizations.of(context).tr('clickMe')),
+              ),
+              new Text(
+                AppLocalizations.of(context).tr('profile.reset_password.title'),
+              ),
             ],
           ),
         ),
-        floatingActionButton: FloatingActionButton(onPressed: incrementCounter,child: Text('+1'),),
+        floatingActionButton: FloatingActionButton(
+          onPressed: incrementCounter,
+          child: Text('+1'),
+        ),
       ),
     );
   }

--- a/example/resources/langs/en-US.json
+++ b/example/resources/langs/en-US.json
@@ -1,7 +1,14 @@
 {
   "title": "Hello",
-  "msg":"Hello {} in the {} world ",
-  "clickMe":"Click me",
+  "msg": "Hello {} in the {} world ",
+  "clickMe": "Click me",
+  "profile": {
+    "reset_password": {
+      "title": "Reset Password",
+      "username": "Username",
+      "password": "password"
+    }
+  },
   "clicked": {
     "zero": "You clicked {} times!",
     "one": "You clicked {} time!",

--- a/lib/easy_localization_delegate.dart
+++ b/lib/easy_localization_delegate.dart
@@ -32,7 +32,7 @@ class AppLocalizations {
   }
 
   String tr(String key, {List<String> args}) {
-    String res = this._sentences[key].toString();
+    String res = this._resolve(key, this._sentences);
     if (args != null) {
       args.forEach((String str) {
         res = res.replaceFirst(RegExp(r'{}'), str);
@@ -51,6 +51,23 @@ class AppLocalizations {
       res = this._sentences[key]['other'];
     }
     return res.replaceFirst(RegExp(r'{}'), '$value');
+  }
+
+  String _resolve(String path, dynamic obj) {
+    List<String> keys = path.split('.');
+
+    if (keys.length > 1) {
+      for (int index = 0; index <= keys.length; index++) {
+        if (obj.containsKey(keys[index]) && obj[keys[index]] is! String) {
+          return _resolve(
+              keys.sublist(index + 1, keys.length).join('.'), obj[keys[index]]);
+        }
+
+        return obj[path] ?? path;
+      }
+    }
+
+    return obj[path] ?? path;
   }
 }
 


### PR DESCRIPTION
1 - add property resolver for nested key translations like "profile.reset_password.title" 
2 - return translate key if the element or path not exist

```
{
  "title": "Hello",
  "msg": "Hello {} in the {} world ",
  "clickMe": "Click me",
  "profile": {
    "reset_password": {
      "title": "Reset Password",
      "username": "Username",
      "password": "password"
    }
  },
  "clicked": {
    "zero": "You clicked {} times!",
    "one": "You clicked {} time!",
    "other": "You clicked {} times!"
  }
}

new Text(
  AppLocalizations.of(context).tr('profile.reset_password.title'),
 ),
```
