### PR TITLE
added support for loading locale from document storage

### DIFF
--- a/lib/easy_localization_delegate.dart
+++ b/lib/easy_localization_delegate.dart
@@ -5,6 +5,7 @@ class EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   final Locale locale;
   final String path;
   final String loadPath;
+  final bool useDocumentStorage;
 
   ///  * use only the lang code to generate i18n file path like en.json or ar.json
   final bool useOnlyLangCode;
@@ -14,6 +15,7 @@ class EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
     this.path,
     this.loadPath,
     this.useOnlyLangCode = false,
+    this.useDocumentStorage = false,
   });
 
   @override
@@ -21,8 +23,13 @@ class EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
 
   @override
   Future<Localization> load(Locale value) async {
-    await Localization.load(value,
-        path: path, loadPath: loadPath, useOnlyLangCode: useOnlyLangCode);
+    await Localization.load(
+      value,
+      path: path,
+      loadPath: loadPath,
+      useOnlyLangCode: useOnlyLangCode,
+      useDocumentStorage: useDocumentStorage,
+    );
 
     return Localization.instance;
   }

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:ui';
 
 
@@ -21,7 +22,7 @@ class Localization {
   //   instance._locale = locale;
   // }
 
-  static Future<bool> load(Locale locale,{String path, String loadPath, bool useOnlyLangCode}) async {
+  static Future<bool> load(Locale locale,{String path, String loadPath, bool useOnlyLangCode, bool useDocumentStorage}) async {
     String data;
 
     var _codeLang = locale.languageCode;
@@ -34,7 +35,12 @@ class Localization {
     localePath += useOnlyLangCode ? '.json' : '-$_codeCoun.json';
 
     if (path != null) {
-      data = await rootBundle.loadString(localePath);
+      if (useDocumentStorage) {
+        File file = File(localePath);
+        data = await file.readAsString();
+      } else {
+        data = await rootBundle.loadString(localePath);
+      }
     } else if (loadPath != null) {
       data = await http
           .get(localePath)


### PR DESCRIPTION
I needed the ability to load the json files from the document storage path instead of the assets bundle path.

If you would like, relatively small change.

*Use case*
In my application I wanted the ability to update locale without having to re-deploy which requires the files to be stored in the document storage and not bundle storage. In order for this to work on android the file need to be loaded using `file.readAsString` and not `rootBundle.loadString` which as I understand it is purely for loading the assets in the bundle.