### PR TITLE
Rebuild the wrapper widget architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -623,3 +623,6 @@ example/.metadata
 test/.test_coverage.dart
 coverage/lcov.info
 pubspec.lock
+.idea/codeStyles/Project.xml
+
+example/ios/Runner.xcodeproj/project.pbxproj

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,23 +12,19 @@ void main() {
     child: MyApp(),
     supportedLocales: [
       Locale('en', 'US'),
-      Locale('de', 'DE'),
       Locale('ar', 'DZ'),
+      Locale('de', 'DE'),
       Locale('ru', 'RU')
     ],
     path: 'resources/langs',
-    // saveLocale: false,
-    // fallbackLocale: Locale('en', 'US'),
+//    saveLocale: false,
     // useOnlyLangCode: true,
-    // saveLocale: false,
     // optional assetLoader default used is RootBundleAssetLoader which uses flutter's assetloader
     // assetLoader: RootBundleAssetLoader()
     // assetLoader: NetworkAssetLoader()
     // assetLoader: TestsAssetLoader()
     // assetLoader: FileAssetLoader()
     // assetLoader: StringAssetLoader()
-    // preloaderWidget: CircularProgressIndicator(),
-    // preloaderColor: Colors.red,
     // onLocaleChange: (){print('Locale change callback!!!');},
   ));
 }
@@ -38,8 +34,6 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     log(EasyLocalization.of(context).locale.toString(),
         name: this.toString() + "# locale");
-    log(Intl.defaultLocale.toString(),
-        name: this.toString() + "# Intl.defaultLocale");
     return MaterialApp(
       title: 'Flutter Demo',
       localizationsDelegates: [
@@ -162,7 +156,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: Text('reset_locale').tr(),
             ),
             Spacer(
-              flex: 2,
+              flex: 1,
             ),
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,10 +7,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:easy_localization/easy_localization.dart';
 
-void main(){
+void main() {
   runApp(EasyLocalization(
     child: MyApp(),
-    supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ'), Locale('ru', 'RU')],
+    supportedLocales: [
+      Locale('en', 'US'),
+      Locale('de', 'DE'),
+      Locale('ar', 'DZ'),
+      Locale('ru', 'RU')
+    ],
     path: 'resources/langs',
     // saveLocale: false,
     // fallbackLocale: Locale('en', 'US'),
@@ -31,8 +36,10 @@ void main(){
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    log( EasyLocalization.of(context).locale.toString(), name: this.toString()+"# locale" );
-    log( Intl.defaultLocale.toString(), name: this.toString()+"# Intl.defaultLocale" );
+    log(EasyLocalization.of(context).locale.toString(),
+        name: this.toString() + "# locale");
+    log(Intl.defaultLocale.toString(),
+        name: this.toString() + "# Intl.defaultLocale");
     return MaterialApp(
       title: 'Flutter Demo',
       localizationsDelegates: [
@@ -140,8 +147,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Text(
                 plural('amount', counter,
                     format: NumberFormat.currency(
-                        locale: Intl.defaultLocale,
-                        symbol: "€")),
+                        locale: Intl.defaultLocale, symbol: "€")),
                 style: TextStyle(
                     color: Colors.grey.shade900,
                     fontSize: 18,
@@ -152,10 +158,9 @@ class _MyHomePageState extends State<MyHomePage> {
             RaisedButton(
               onPressed: () {
                 EasyLocalization.of(context).deleteSaveLocale();
-                },
-              child: Text('reset_locale').tr(), 
-            )
-            ,
+              },
+              child: Text('reset_locale').tr(),
+            ),
             Spacer(
               flex: 2,
             ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -46,12 +46,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
-    - resources/langs/ar-DZ.json
-    - resources/langs/ar.json
-    - resources/langs/en-US.json
-    - resources/langs/en.json
-    - resources/langs/ru-RU.json
-    - resources/langs/ru.json
+    - resources/langs/
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/example/resources/langs/de-DE.json
+++ b/example/resources/langs/de-DE.json
@@ -1,0 +1,37 @@
+{
+  "title": "Hallo",
+  "msg": "Hallo {} in der {} welt ",
+  "clickMe": "Click mich",
+  "profile": {
+    "reset_password": {
+      "title": "Password zurücksetzten",
+      "username": "Name",
+      "password": "Password"
+    }
+  },
+  "clicked": {
+    "zero": "Du hast {} mal geklickt",
+    "one": "Du hast {} mal geklickt",
+    "two": "Du hast {} mal geklickt",
+    "few": "Du hast {} mal geklickt",
+    "many": "Du hast {} mal geklickt",
+    "other": "Du hast {} mal geklickt"
+  },
+  "amount": {
+    "zero": "Deine Klicks: {}",
+    "one": "Deine Klicks: {}",
+    "two": "Deine Klicks: {}",
+    "few": "Deine Klicks: {}",
+    "many": "Deine Klicks: {}",
+    "other": "Deine Klicks: {}"
+  },
+  "switch": {
+    "male": "Hi Mann ;) ",
+    "female": "Hallo Frau :)",
+    "with_arg": {
+      "male": "Hi Mann ;) {}",
+      "female": "Hallo Frau :) {}"
+    }
+  },
+  "reset_locale": "Gespeicherte Sprache zurücksettzen"
+}

--- a/example/resources/langs/de.json
+++ b/example/resources/langs/de.json
@@ -1,0 +1,37 @@
+{
+  "title": "Hallo",
+  "msg": "Hallo {} in der {} welt ",
+  "clickMe": "Click mich",
+  "profile": {
+    "reset_password": {
+      "title": "Password zurücksetzten",
+      "username": "Name",
+      "password": "Password"
+    }
+  },
+  "clicked": {
+    "zero": "Du hast {} mal geklickt",
+    "one": "Du hast {} mal geklickt",
+    "two": "Du hast {} mal geklickt",
+    "few": "Du hast {} mal geklickt",
+    "many": "Du hast {} mal geklickt",
+    "other": "Du hast {} mal geklickt"
+  },
+  "amount": {
+    "zero": "Deine Klicks: {}",
+    "one": "Deine Klicks: {}",
+    "two": "Deine Klicks: {}",
+    "few": "Deine Klicks: {}",
+    "many": "Deine Klicks: {}",
+    "other": "Deine Klicks: {}"
+  },
+  "switch": {
+    "male": "Hi Mann ;) ",
+    "female": "Hallo Frau :)",
+    "with_arg": {
+      "male": "Hi Mann ;) {}",
+      "female": "Hallo Frau :) {}"
+    }
+  },
+  "reset_locale": "Gespeicherte Sprache zurücksettzen"
+}

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -54,7 +54,12 @@ class _EasyLocalizationState extends State<EasyLocalization> {
   @override
   void initState() {
     if (widget.saveLocale) loadSavedLocale();
-    delegate.onLocaleChanged = _onLocaleChanged;
+    delegate.onLocaleChanged = (locale) {
+      if (this.locale == null)
+        setState(() {
+          this.locale = locale;
+        });
+    };
     super.initState();
   }
 
@@ -155,9 +160,7 @@ class EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       useOnlyLangCode: useOnlyLangCode,
       assetLoader: assetLoader,
     );
-    if (onLocaleChanged != null && value == loadedLocale) {
-      onLocaleChanged(value);
-    }
+    onLocaleChanged(value);
     return Localization.instance;
   }
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -57,10 +57,11 @@ class _EasyLocalizationState extends State<EasyLocalization> {
     SharedPreferences _preferences = await SharedPreferences.getInstance();
     var _codeLang = _preferences.getString('codeLa');
     var _codeCoun = _preferences.getString('codeCa');
-    if (_codeLang != null) {
+    var _strLocale = _preferences.getString('locale');
+    if (_strLocale != null) {
       log('easy localization: Locale loaded from shared preferences ${Locale(_codeLang, _codeCoun)}');
       setState(() {
-        locale = Locale(_codeLang, _codeCoun);
+        locale = _localeFromString(_strLocale);
       });
     }
     // TODO reload delegate, set on Material Widget

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -53,8 +53,9 @@ class _EasyLocalizationState extends State<EasyLocalization> {
 
   @override
   void initState() {
-    loadSavedLocale();
+    if (widget.saveLocale) loadSavedLocale();
     delegate.onLocaleChanged = _onLocaleChanged;
+    super.initState();
   }
 
   loadSavedLocale() async {
@@ -82,7 +83,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
 }
 
 class EasyLocalizationProvider extends InheritedWidget {
-  EasyLocalization parent;
+  final EasyLocalization parent;
   final Locale _locale;
   final ValueChanged<Locale> onLocaleChanged;
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -1,137 +1,108 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-import "package:intl/intl_standalone.dart";
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'asset_loader.dart';
 import 'localization.dart';
-import 'widgets.dart';
 
 class EasyLocalization extends StatefulWidget {
-  final Widget child;
   final List<Locale> supportedLocales;
-  final Locale fallbackLocale;
-  final _EasyLocalizationDelegate delegate;
   final bool useOnlyLangCode;
   final String path;
   final AssetLoader assetLoader;
+  final Widget child;
   final bool saveLocale;
-  final Widget preloaderWidget;
-  final Color preloaderColor;
-  final VoidCallback onLocaleChange;
+
   EasyLocalization({
     Key key,
-    @required this.child,
     @required this.supportedLocales,
     @required this.path,
-    this.fallbackLocale,
     this.useOnlyLangCode = false,
     this.assetLoader = const RootBundleAssetLoader(),
     this.saveLocale = true,
-    this.preloaderWidget = const EmptyPreloaderWidget(),
-    this.preloaderColor = Colors.white,
-    this.onLocaleChange,
-  })  : //assert(supportedLocales.contains(fallbackLocale)),
-        delegate = _EasyLocalizationDelegate(
-            path: path,
-            supportedLocales: supportedLocales,
-            useOnlyLangCode: useOnlyLangCode,
-            assetLoader: assetLoader),
-        super(key: key);
+    this.child,
+  }) : super(key: key);
 
+  static EasyLocalizationProvider of(BuildContext context) =>
+      EasyLocalizationProvider.of(context);
+
+  @override
   _EasyLocalizationState createState() => _EasyLocalizationState();
-
-  static _EasyLocalizationState of(BuildContext context) =>
-      _EasyLocalizationProvider.of(context).data;
 }
 
-class _EasyLocalizationLocale extends ChangeNotifier {
-  Locale _locale;
-  static Locale _savedLocale;
-  static Locale _osLocale;
-  bool saveLocale;
-  VoidCallback onLocaleChange;
+class _EasyLocalizationState extends State<EasyLocalization> {
+  Locale locale;
+  EasyLocalizationDelegate delegate;
 
-  // @TOGO maybe add assertion to ensure that ensureInitialized has been called and that
-  // _savedLocale is set.
-  _EasyLocalizationLocale(
-      Locale fallbackLocale, List<Locale> supportedLocales, bool saveLocale, VoidCallback onLocaleChange)
-      : this.saveLocale = saveLocale,
-        this.onLocaleChange = onLocaleChange {
-    _init(fallbackLocale, supportedLocales);
+  _onLocaleChanged(Locale locale, [bool rebuild = true]) {
+    if (rebuild)
+      setState(() {
+        this.locale = locale;
+      });
+    else
+      this.locale = locale;
   }
 
-  //Initialize _EasyLocalizationLocale
-  _init(Locale fallbackLocale, List<Locale> supportedLocales){
-    // If saved locale then get
-    if (_savedLocale != null && this.saveLocale) {
-      log('easy localization: Saved locale loaded ${_savedLocale.toString()}');
-      locale = _savedLocale;      
-    } else {
-      locale = supportedLocales.firstWhere((locale) => _checkInitLocale(locale, _osLocale),
-          orElse: () => _getFallbackLocale(supportedLocales, fallbackLocale));
+  @override
+  void initState() {
+    loadSavedLocale();
+    delegate = EasyLocalizationDelegate(
+        path: widget.path,
+        supportedLocales: widget.supportedLocales,
+        useOnlyLangCode: widget.useOnlyLangCode,
+        assetLoader: widget.assetLoader,
+        onLocaleChanged: (locale) {
+          _onLocaleChanged(locale, false);
+        });
+  }
+
+  loadSavedLocale() async {
+    SharedPreferences _preferences = await SharedPreferences.getInstance();
+    var _codeLang = _preferences.getString('codeLa');
+    var _codeCoun = _preferences.getString('codeCa');
+    if (_codeLang != null) {
+      log('easy localization: Locale loaded from shared preferences ${Locale(_codeLang, _codeCoun)}');
+      setState(() {
+        locale = Locale(_codeLang, _codeCoun);
+      });
     }
-    //Set locale
-    if (Intl.defaultLocale == null) locale = _locale;    
+    // TODO reload delegate, set on Material Widget
   }
 
-  bool _checkInitLocale(Locale locale, Locale osLocale) {
-    // If suported locale not contain countryCode then check only languageCode
-    if (locale.countryCode == null) {
-      return (locale.languageCode == _osLocale.languageCode);      
-    } else {
-      return (locale == _osLocale);
-    }
+  @override
+  Widget build(BuildContext context) {
+    return EasyLocalizationProvider(
+      widget,
+      this.locale,
+      child: widget.child,
+      onLocaleChanged: _onLocaleChanged,
+      delegate: delegate,
+    );
   }
+}
 
-  //Get fallback Locale
-  Locale _getFallbackLocale(
-      List<Locale> supportedLocales, Locale fallbackLocale) {
-    //If fallbackLocale not set then return first from supportedLocales
-    if (fallbackLocale != null) {
-      return fallbackLocale;
-    } else {
-      return supportedLocales.first;
-    }
-  }
+class EasyLocalizationProvider extends InheritedWidget {
+  EasyLocalization parent;
+  final Locale _locale;
+  final ValueChanged<Locale> onLocaleChanged;
 
-  // Get Device Locale
-  static Future initDeviceLocale() async {
-    final String _deviceLocale = await findSystemLocale();
-    final _deviceLocaleList = _deviceLocale.split("_");
-    
-    _osLocale = (_deviceLocaleList.length > 1)
-        ? Locale(_deviceLocaleList[0], _deviceLocaleList[1])
-        : Locale(_deviceLocaleList[0]);
+  List<Locale> get supportedLocales => parent.supportedLocales;
 
-  log('easy localization: Device locale ${_osLocale.toString()}');
-  }
+  final EasyLocalizationDelegate delegate;
+
+  EasyLocalizationProvider(this.parent, this._locale,
+      {Key key, Widget child, this.onLocaleChanged, this.delegate})
+      : super(key: key, child: child);
 
   Locale get locale => _locale;
-  set locale(Locale l) {
-    
-    if (_locale != l){
-      Locale _oldLocale = _locale;
-      _locale = l;
 
-      if (_locale != null)
-        Intl.defaultLocale = Intl.canonicalizedLocale(
-            l.countryCode == null || l.countryCode.isEmpty
-                ? l.languageCode
-                : l.toString());
-
-      if (this.saveLocale) _saveLocale(_locale);
-      log('easy localization: Set locale ${this.locale.toString()}');
-      
-      notifyListeners();
-
-      if (onLocaleChange != null && _oldLocale != null) onLocaleChange();
-    }
+  set locale(Locale locale) {
+    assert(parent.supportedLocales.contains(locale));
+    if (parent.saveLocale) _saveLocale(locale);
+    log('easy localization: Locale set ${locale.toString()}');
+    onLocaleChanged(locale);
   }
-
-  Locale get deviceLocale => _osLocale;
 
   _saveLocale(Locale locale) async {
     SharedPreferences _preferences = await SharedPreferences.getInstance();
@@ -140,124 +111,39 @@ class _EasyLocalizationLocale extends ChangeNotifier {
     log('easy localization: Locale saved ${locale.toString()}');
   }
 
-  deleteSaveLocale() async{
+  deleteSaveLocale() async {
     SharedPreferences _preferences = await SharedPreferences.getInstance();
     await _preferences.setString('codeCa', null);
     await _preferences.setString('codeLa', null);
     log('easy localization: Saved locale deleted');
   }
-  
-  static Future initSavedAppLocale() async {
-    SharedPreferences _preferences = await SharedPreferences.getInstance();
-    var _codeLang = _preferences.getString('codeLa');
-    var _codeCoun = _preferences.getString('codeCa');
 
-    _savedLocale = _codeLang != null ? Locale(_codeLang, _codeCoun) : null;
+  @override
+  bool updateShouldNotify(EasyLocalizationProvider oldWidget) {
+    return oldWidget._locale != this._locale;
   }
+
+  static EasyLocalizationProvider of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<EasyLocalizationProvider>();
 }
 
-class _EasyLocalizationState extends State<EasyLocalization> {
-  _EasyLocalizationLocale _locale;
-  Future _futureSavedAppLocale;
-  Future _futureInitDeviceLocale; 
-
-  Locale get locale => _locale.locale;
-  Locale get deviceLocale => _locale.deviceLocale;
-
-  set locale(Locale l) {
-    if (!supportedLocales.contains(l))
-      throw new Exception("Locale $l is not supported by this app.");
-    _locale.locale = l;
-  }
-
-  List<Locale> get supportedLocales => widget.supportedLocales;
-  _EasyLocalizationDelegate get delegate => widget.delegate;
-  Locale get fallbackLocale => widget.fallbackLocale;
-  bool get saveLocale => widget.saveLocale;
-  VoidCallback get onLocaleChange => widget.onLocaleChange;
-
-
-  @override
-  void dispose() {
-    _locale.dispose();
-    super.dispose();
-  }
-
-  @override
-  void initState() {
-    //init _EasyLocalizationLocale only once
-    //if saveLocale false then return blank future
-    _futureSavedAppLocale = saveLocale
-        ? _EasyLocalizationLocale.initSavedAppLocale()
-        : Future.value();
-
-    //init device locale once
-    _futureInitDeviceLocale = _EasyLocalizationLocale.initDeviceLocale();
-
-    //Init locale engine
-    _locale =
-        _EasyLocalizationLocale(fallbackLocale, supportedLocales, saveLocale, onLocaleChange);
-    this._locale.addListener(() {
-      if (mounted) setState(() {});
-    });
-    super.initState();
-  }
-  //delete saved locale
-  void deleteSaveLocale() => _locale.deleteSaveLocale(); 
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      color: widget.preloaderColor,
-      child: FutureBuilder<List>(
-        //init saved locale and device locale
-        future: Future.wait([_futureSavedAppLocale, _futureInitDeviceLocale]),
-        builder: (BuildContext context,
-            AsyncSnapshot<List> snapshot) {
-          if (snapshot.hasData) {
-            return _EasyLocalizationProvider(
-              data: this,
-              child: widget.child,
-            );
-          } else if (snapshot.hasError){
-            //Show error message       
-            return const FutureErrorWidget();
-          } else {
-            //Show preloader widget
-            return widget.preloaderWidget;
-          }
-        },
-      ),
-    );
-  }
-}
-
-class _EasyLocalizationProvider extends InheritedWidget {
-  _EasyLocalizationProvider({Key key, this.child, this.data})
-      : super(key: key, child: child);
-  final _EasyLocalizationState data;
-  final Widget child;
-
-  static _EasyLocalizationProvider of(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<_EasyLocalizationProvider>();
-
-  @override
-  bool updateShouldNotify(_EasyLocalizationProvider oldWidget) => true;
-}
-
-class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
+class EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   final String path;
   final AssetLoader assetLoader;
   final List<Locale> supportedLocales;
+  final ValueChanged<Locale> onLocaleChanged;
 
   ///  * use only the lang code to generate i18n file path like en.json or ar.json
   final bool useOnlyLangCode;
 
-  _EasyLocalizationDelegate(
+  Locale loadedLocale;
+
+  EasyLocalizationDelegate(
       {@required this.path,
       @required this.supportedLocales,
       this.useOnlyLangCode = false,
-      this.assetLoader});
+      this.assetLoader,
+      this.onLocaleChanged});
 
   @override
   bool isSupported(Locale locale) => supportedLocales.contains(locale);
@@ -270,9 +156,15 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       useOnlyLangCode: useOnlyLangCode,
       assetLoader: assetLoader,
     );
+    loadedLocale = value;
+    if (onLocaleChanged != null) {
+      onLocaleChanged(value);
+    }
     return Localization.instance;
   }
 
   @override
-  bool shouldReload(LocalizationsDelegate<Localization> old) => false;
+  bool shouldReload(EasyLocalizationDelegate old) {
+    return loadedLocale != old.loadedLocale;
+  }
 }

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -55,13 +55,13 @@ class _EasyLocalizationState extends State<EasyLocalization> {
 
   loadSavedLocale() async {
     SharedPreferences _preferences = await SharedPreferences.getInstance();
-    var _codeLang = _preferences.getString('codeLa');
-    var _codeCoun = _preferences.getString('codeCa');
     var _strLocale = _preferences.getString('locale');
+    print(_strLocale);
     if (_strLocale != null) {
-      log('easy localization: Locale loaded from shared preferences ${Locale(_codeLang, _codeCoun)}');
+      log('easy localization: Locale loaded from shared preferences ${_strLocale}');
       setState(() {
         locale = _localeFromString(_strLocale);
+        print(locale);
       });
     }
     // TODO reload delegate, set on Material Widget

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -35,13 +35,10 @@ class _EasyLocalizationState extends State<EasyLocalization> {
   Locale locale;
   EasyLocalizationDelegate delegate;
 
-  _onLocaleChanged(Locale locale, [bool rebuild = true]) {
-    if (rebuild)
-      setState(() {
-        this.locale = locale;
-      });
-    else
+  _onLocaleChanged(Locale locale) {
+    setState(() {
       this.locale = locale;
+    });
   }
 
   @override
@@ -52,9 +49,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
         supportedLocales: widget.supportedLocales,
         useOnlyLangCode: widget.useOnlyLangCode,
         assetLoader: widget.assetLoader,
-        onLocaleChanged: (locale) {
-          _onLocaleChanged(locale, false);
-        });
+        onLocaleChanged: _onLocaleChanged);
   }
 
   loadSavedLocale() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,7 +85,7 @@ packages:
     source: hosted
     version: "2.1.4"
   intl:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
@@ -107,13 +112,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -202,7 +200,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: easy_localization
 description: Easy and Fast internationalizing and localization your Flutter Apps, this package simplify the internationalizing process using Json file.
 
-version: 2.0.1
+version: 2.1.0
 
 #author: AISSAT abdelwahab <mr.aissat@gmail.com>
 homepage: https://github.com/aissat/easy_localization

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.16.0
+  flutter_localizations:
+    sdk: flutter
   shared_preferences: ^0.5.6+1
 
 dev_dependencies:

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -471,11 +471,11 @@ void main() {
 
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en"), Locale("ar")]);
-          expect(EasyLocalization.of(_context).locale, Locale("ar"));
+          expect(EasyLocalization.of(_context).locale, Locale("en"));
 
-          expect(Intl.defaultLocale, Locale("ar").toString());
-          expect(Intl.defaultLocale,
-              EasyLocalization.of(_context).locale.toString());
+//          expect(Intl.defaultLocale, Locale("ar").toString());
+//          expect(Intl.defaultLocale,
+//              EasyLocalization.of(_context).locale.toString());
         });
       },
     );

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -415,7 +415,9 @@ void main() {
 
   group('SharedPreferences SavedLocale NULL', () {
     setUp(() {
-      SharedPreferences.setMockInitialValues({"locale": null,});
+      SharedPreferences.setMockInitialValues({
+        "locale": null,
+      });
     });
 
     testWidgets(
@@ -447,11 +449,13 @@ void main() {
 
   group('SharedPreferences saveLocale', () {
     setUpAll(() {
-      SharedPreferences.setMockInitialValues({"locale": "ar",});
+      SharedPreferences.setMockInitialValues({
+        "locale": "ar",
+      });
     });
 
     testWidgets(
-      "[EasyLocalization] useOnlyLangCode true  test",
+      "[EasyLocalization] useOnlyLangCode true test",
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
@@ -471,7 +475,7 @@ void main() {
 
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en"), Locale("ar")]);
-          expect(EasyLocalization.of(_context).locale, Locale("en"));
+          expect(EasyLocalization.of(_context).locale, Locale("ar"));
 
 //          expect(Intl.defaultLocale, Locale("ar").toString());
 //          expect(Intl.defaultLocale,
@@ -479,15 +483,13 @@ void main() {
         });
       },
     );
-
-
   });
 
-
-
-group('SharedPreferences saveLocale', () {
+  group('SharedPreferences saveLocale', () {
     setUpAll(() {
-      SharedPreferences.setMockInitialValues({"locale": "ar_DZ",});
+      SharedPreferences.setMockInitialValues({
+        "locale": "ar_DZ",
+      });
     });
 
     testWidgets(
@@ -520,7 +522,7 @@ group('SharedPreferences saveLocale', () {
     );
 
     testWidgets(
-      "[EasyLocalization] saveLocale false  test",
+      "[EasyLocalization] saveLocale false test",
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
@@ -543,10 +545,59 @@ group('SharedPreferences saveLocale', () {
 
 //          expect(Intl.defaultLocale, Locale("en", "US").toString());
 //          expect(Intl.defaultLocale,
-//              EasyLocalization.of(_context).locale.toString());
+        });
+      },
+    );
+  });
+  group('SharedPreferences deleteSaveLocale()', () {
+    setUpAll(() {
+      SharedPreferences.setMockInitialValues({
+        "locale": "ar_DZ",
+      });
+    });
+    testWidgets(
+      "[EasyLocalization] deleteSaveLocale  test",
+      (WidgetTester tester) async {
+        await tester.runAsync(() async {
+          await tester.pumpWidget(EasyLocalization(
+            child: MyApp(),
+            path: "i18n",
+            // fallbackLocale:Locale("en") ,
+            supportedLocales: [
+              Locale("en", "US"),
+              Locale("ar", "DZ")
+            ], // Locale("en", "US"), Locale("ar","DZ")
+          ));
+          await tester.idle();
+          // The async delegator load will require build on the next frame. Thus, pump
+          await tester.pumpAndSettle();
+
+          expect(EasyLocalization.of(_context).locale, Locale("ar", "DZ"));
+          EasyLocalization.of(_context).deleteSaveLocale();
         });
       },
     );
 
+    testWidgets(
+      "[EasyLocalization] after deleteSaveLocale test",
+      (WidgetTester tester) async {
+        await tester.runAsync(() async {
+          await tester.pumpWidget(EasyLocalization(
+            child: MyApp(),
+            path: "i18n",
+            // fallbackLocale:Locale("en") ,
+            supportedLocales: [
+              Locale("en", "US"),
+              Locale("ar", "DZ")
+            ], // Locale("en", "US"), Locale("ar","DZ")
+          ));
+          await tester.idle();
+          // The async delegator load will require build on the next frame. Thus, pump
+          await tester.pumpAndSettle();
+
+          expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
+        });
+      },
+    );
   });
 }

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -50,6 +50,7 @@ void main() {
           assetLoader: JsonAssetLoader(),
         ));
         await tester.idle();
+//        await tester.pump(Duration(milliseconds: 400));
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pumpAndSettle();
 
@@ -57,9 +58,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US")]);
         expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-        expect(Intl.defaultLocale, Locale("en", "US").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en", "US").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         final trFinder = find.text('test');
         expect(trFinder, findsOneWidget);
@@ -91,9 +92,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US")]);
         expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-        expect(Intl.defaultLocale, Locale("en", "US").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en", "US").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         final trFinder = find.text('test');
         expect(trFinder, findsOneWidget);
@@ -123,9 +124,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US")]);
         expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-        expect(Intl.defaultLocale, Locale("en", "US").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en", "US").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         final trFinder = find.text('test');
         expect(trFinder, findsOneWidget);
@@ -156,9 +157,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US"), Locale("en")]);
         expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-        expect(Intl.defaultLocale, Locale("en", "US").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en", "US").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         var l = Locale("en", "US");
         EasyLocalization.of(_context).locale = l;
@@ -174,11 +175,11 @@ void main() {
         expect(plural("day", 2, context: _context), "2 days");
         expect(plural("day", 3, context: _context), "3 other days");
         expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-        expect(Intl.defaultLocale, Locale("en", "US").toString());
+//        expect(Intl.defaultLocale, Locale("en", "US").toString());
 
         l = Locale("ar", "DZ");
-        expect(
-            () => {EasyLocalization.of(_context).locale = l}, throwsException);
+        expect(() => {EasyLocalization.of(_context).locale = l},
+            throwsAssertionError);
 
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US"), Locale("en")]);
@@ -186,6 +187,7 @@ void main() {
 
         l = Locale("en");
         EasyLocalization.of(_context).locale = l;
+        await tester.pumpAndSettle();
         expect(EasyLocalization.of(_context).locale, l);
 
         EasyLocalization.of(_context).locale = Locale("en", "US");
@@ -224,24 +226,27 @@ void main() {
         var l = Locale("en", "US");
         EasyLocalization.of(_context).locale = l;
         expect(EasyLocalization.of(_context).locale, l);
-        expect(Intl.defaultLocale, l.toString());
+//        expect(Intl.defaultLocale, l.toString());
 
         l = Locale("ar", "DZ");
         EasyLocalization.of(_context).locale = l;
+        await tester.pumpAndSettle();
         expect(EasyLocalization.of(_context).locale, l);
-        expect(Intl.defaultLocale, l.toString());
+//        expect(Intl.defaultLocale, l.toString());
 
         l = Locale("en", "US");
         EasyLocalization.of(_context).locale = l;
+        await tester.pumpAndSettle();
         expect(EasyLocalization.of(_context).locale, l);
-        expect(Intl.defaultLocale, l.toString());
+//        expect(Intl.defaultLocale, l.toString());
 
         l = Locale("en", "UK");
-        expect(
-            () => {EasyLocalization.of(_context).locale = l}, throwsException);
+        expect(() => {EasyLocalization.of(_context).locale = l},
+            throwsAssertionError);
 
         l = Locale("ar", "DZ");
         EasyLocalization.of(_context).locale = l;
+        await tester.pumpAndSettle();
         expect(EasyLocalization.of(_context).locale, l);
       });
     },
@@ -268,9 +273,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en", "US"), Locale("ar", "DZ")]);
         expect(EasyLocalization.of(_context).locale, Locale("ar", "DZ"));
-        expect(Intl.defaultLocale, Locale("ar", "DZ").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("ar", "DZ").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         var trFinder = find.text('اختبار');
         expect(trFinder, findsOneWidget);
@@ -311,9 +316,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en"), Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("en"));
-        expect(Intl.defaultLocale, Locale("en").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         var l = Locale("en");
         EasyLocalization.of(_context).locale = l;
@@ -344,9 +349,9 @@ void main() {
             [Locale("en"), Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("en"));
 
-        expect(Intl.defaultLocale, Locale("en").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("en").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
 
         var l = Locale("en");
         EasyLocalization.of(_context).locale = l;
@@ -373,9 +378,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales, [Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("ar"));
 
-        expect(Intl.defaultLocale, Locale("ar").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("ar").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
       });
     },
   );
@@ -401,9 +406,9 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales, [Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("ar"));
 
-        expect(Intl.defaultLocale, Locale("ar").toString());
-        expect(Intl.defaultLocale,
-            EasyLocalization.of(_context).locale.toString());
+//        expect(Intl.defaultLocale, Locale("ar").toString());
+//        expect(Intl.defaultLocale,
+//            EasyLocalization.of(_context).locale.toString());
       });
     },
   );
@@ -424,16 +429,17 @@ void main() {
             supportedLocales: [Locale("en", "US"), Locale("ar", "DZ")], //
           ));
           await tester.idle();
+          await tester.pump(Duration(seconds: 2));
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en", "US"), Locale("ar", "DZ")]);
-          expect(EasyLocalization.of(_context).locale, Locale("ar", "DZ"));
+          expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
 
-          expect(Intl.defaultLocale, Locale("ar", "DZ").toString());
-          expect(Intl.defaultLocale,
-              EasyLocalization.of(_context).locale.toString());
+//          expect(Intl.defaultLocale, Locale("ar", "DZ").toString());
+//          expect(Intl.defaultLocale,
+//              EasyLocalization.of(_context).locale.toString());
         });
       },
     );
@@ -466,9 +472,9 @@ void main() {
               [Locale("en", "US"), Locale("ar", "DZ")]);
           expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
 
-          expect(Intl.defaultLocale, Locale("en", "US").toString());
-          expect(Intl.defaultLocale,
-              EasyLocalization.of(_context).locale.toString());
+//          expect(Intl.defaultLocale, Locale("en", "US").toString());
+//          expect(Intl.defaultLocale,
+//              EasyLocalization.of(_context).locale.toString());
         });
       },
     );
@@ -495,9 +501,9 @@ void main() {
               [Locale("en", "US"), Locale("ar", "DZ")]);
           expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
 
-          expect(Intl.defaultLocale, Locale("en", "US").toString());
-          expect(Intl.defaultLocale,
-              EasyLocalization.of(_context).locale.toString());
+//          expect(Intl.defaultLocale, Locale("en", "US").toString());
+//          expect(Intl.defaultLocale,
+//              EasyLocalization.of(_context).locale.toString());
         });
       },
     );

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -303,7 +303,6 @@ void main() {
             Locale("en"),
             Locale("ar")
           ], // Locale("en", "US"), Locale("ar","DZ")
-          fallbackLocale: Locale("en"), // Locale("ar","DZ"),
         ));
         await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -344,7 +343,6 @@ void main() {
         expect(EasyLocalization.of(_context).supportedLocales,
             [Locale("en"), Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("en"));
-        expect(EasyLocalization.of(_context).fallbackLocale, null);
 
         expect(Intl.defaultLocale, Locale("en").toString());
         expect(Intl.defaultLocale,
@@ -366,7 +364,6 @@ void main() {
           path: "i18n",
           saveLocale: false,
           useOnlyLangCode: true,
-          fallbackLocale: Locale("ar"),
           supportedLocales: [Locale("ar")],
         ));
         await tester.idle();
@@ -375,7 +372,6 @@ void main() {
 
         expect(EasyLocalization.of(_context).supportedLocales, [Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("ar"));
-        expect(EasyLocalization.of(_context).fallbackLocale, Locale("ar"));
 
         expect(Intl.defaultLocale, Locale("ar").toString());
         expect(Intl.defaultLocale,
@@ -404,7 +400,6 @@ void main() {
 
         expect(EasyLocalization.of(_context).supportedLocales, [Locale("ar")]);
         expect(EasyLocalization.of(_context).locale, Locale("ar"));
-        expect(EasyLocalization.of(_context).fallbackLocale, null);
 
         expect(Intl.defaultLocale, Locale("ar").toString());
         expect(Intl.defaultLocale,
@@ -435,7 +430,6 @@ void main() {
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en", "US"), Locale("ar", "DZ")]);
           expect(EasyLocalization.of(_context).locale, Locale("ar", "DZ"));
-          expect(EasyLocalization.of(_context).fallbackLocale, null);
 
           expect(Intl.defaultLocale, Locale("ar", "DZ").toString());
           expect(Intl.defaultLocale,
@@ -471,7 +465,6 @@ void main() {
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en", "US"), Locale("ar", "DZ")]);
           expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-          expect(EasyLocalization.of(_context).fallbackLocale, null);
 
           expect(Intl.defaultLocale, Locale("en", "US").toString());
           expect(Intl.defaultLocale,
@@ -501,7 +494,6 @@ void main() {
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en", "US"), Locale("ar", "DZ")]);
           expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
-          expect(EasyLocalization.of(_context).fallbackLocale, null);
 
           expect(Intl.defaultLocale, Locale("en", "US").toString());
           expect(Intl.defaultLocale,
@@ -510,6 +502,4 @@ void main() {
       },
     );
   });
-
- 
 }

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -472,7 +472,6 @@ void main() {
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en"), Locale("ar")]);
           expect(EasyLocalization.of(_context).locale, Locale("ar"));
-          expect(EasyLocalization.of(_context).fallbackLocale, null);
 
           expect(Intl.defaultLocale, Locale("ar").toString());
           expect(Intl.defaultLocale,

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -510,7 +510,7 @@ group('SharedPreferences saveLocale', () {
 
           expect(EasyLocalization.of(_context).supportedLocales,
               [Locale("en", "US"), Locale("ar", "DZ")]);
-          expect(EasyLocalization.of(_context).locale, Locale("en", "US"));
+          expect(EasyLocalization.of(_context).locale, Locale("ar", "DZ"));
 
 //          expect(Intl.defaultLocale, Locale("en", "US").toString());
 //          expect(Intl.defaultLocale,


### PR DESCRIPTION
@aissat @Overman775 I found the time today and rebuild the architecture layer of the top level wrapper widget. I eliminated the `Intl` stuff completly from the config, since I believe it is much safer / more maintainable to just trust the flutter core framework to resolve the device language config and work through the delegate, offering an override logic through the safe persistance. All features are working as expected & tests are passing. Here are the notables: 
* The initialisation of the wrapper is now happening asynchronously, meaning that no more loader or err or widgets are needed, but it will simply refreshes if a persistet locale is found. Otherwise, it is left to the system to select the locale as usual and the library will adapt to it. This will eliminate #39 #98 and #96. Also better architecture not to block anything with async work before the actual app widget. 
* I eliminated the fallback locale, since there is more advanced login to selecting it. I think this should be left up to the system. Generally, according to flutter docs, the first entry of the array will be used as fallback. However, in some cases some translation delegates might not be supporting a fallback or the system has other settings that determine preferred language. I think it is unsafe to force the fallback onto the system through a direct override. 
* I commented out the Intl. Related tests. Im not sure, what the `Intl.defaultLocale` setting actually does. Everything works fine without it. Am I overlooking something here? If so, ping me and ill set it in my implementation. 
* I would consider defaulting the language saving to false. 
* Doc updates are pending, wanted to get your feedback first.

Cheers, Moritz 