### PR TITLE
named arguments support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,7 +130,7 @@ class _MyHomePageState extends State<MyHomePage> {
               flex: 1,
             ),
             Text('msg').tr(args: ['aissat', 'Flutter']),
-            Text('msg_named').tr(namedArgs: {'lang': 'English'}),
+            Text('msg_named').tr(namedArgs: {'lang': 'Dart'}),
             Text('clicked').plural(counter),
             FlatButton(
               onPressed: () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,6 +130,7 @@ class _MyHomePageState extends State<MyHomePage> {
               flex: 1,
             ),
             Text('msg').tr(args: ['aissat', 'Flutter']),
+            Text('msg_named').tr(namedArgs: {'lang': 'English'}),
             Text('clicked').plural(counter),
             FlatButton(
               onPressed: () {

--- a/example/resources/langs/ar-DZ.json
+++ b/example/resources/langs/ar-DZ.json
@@ -1,6 +1,7 @@
 {
     "title": "السلام",
     "msg": "السلام عليكم يا {} في عالم {}",
+    "msg_named": "هذا النص باللغة {lang}",
     "clickMe": "إضغط هنا",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/ar.json
+++ b/example/resources/langs/ar.json
@@ -1,6 +1,7 @@
 {
     "title": "السلام",
     "msg": "السلام عليكم يا {} في عالم {}",
+    "msg_named": "هذا النص باللغة {lang}",
     "clickMe": "إضغط هنا",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/de-DE.json
+++ b/example/resources/langs/de-DE.json
@@ -1,6 +1,7 @@
 {
   "title": "Hallo",
   "msg": "Hallo {} in der {} welt ",
+  "msg_named": "Easy localization ist in {{lang}} geschrieben",
   "clickMe": "Click mich",
   "profile": {
     "reset_password": {

--- a/example/resources/langs/de-DE.json
+++ b/example/resources/langs/de-DE.json
@@ -1,7 +1,7 @@
 {
   "title": "Hallo",
   "msg": "Hallo {} in der {} welt ",
-  "msg_named": "Easy localization ist in {{lang}} geschrieben",
+  "msg_named": "Easy localization ist in {lang} geschrieben",
   "clickMe": "Click mich",
   "profile": {
     "reset_password": {

--- a/example/resources/langs/de.json
+++ b/example/resources/langs/de.json
@@ -1,6 +1,7 @@
 {
   "title": "Hallo",
   "msg": "Hallo {} in der {} welt ",
+  "msg_named": "Easy localization ist in {{lang}} geschrieben",
   "clickMe": "Click mich",
   "profile": {
     "reset_password": {

--- a/example/resources/langs/de.json
+++ b/example/resources/langs/de.json
@@ -1,7 +1,7 @@
 {
   "title": "Hallo",
   "msg": "Hallo {} in der {} welt ",
-  "msg_named": "Easy localization ist in {{lang}} geschrieben",
+  "msg_named": "Easy localization ist in {lang} geschrieben",
   "clickMe": "Click mich",
   "profile": {
     "reset_password": {

--- a/example/resources/langs/en-US.json
+++ b/example/resources/langs/en-US.json
@@ -1,6 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
+    "msg_named": "This text is displayed in {{lang}} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/en-US.json
+++ b/example/resources/langs/en-US.json
@@ -1,7 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
-    "msg_named": "This text is displayed in {{lang}} language",
+    "msg_named": "Easy localization are written in the {{lang}} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/en-US.json
+++ b/example/resources/langs/en-US.json
@@ -1,7 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
-    "msg_named": "Easy localization are written in the {{lang}} language",
+    "msg_named": "Easy localization are written in the {lang} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/en.json
+++ b/example/resources/langs/en.json
@@ -1,6 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
+    "msg_named": "This text is displayed in {{lang}} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/en.json
+++ b/example/resources/langs/en.json
@@ -1,7 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
-    "msg_named": "This text is displayed in {{lang}} language",
+    "msg_named": "Easy localization are written in the {{lang}} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/en.json
+++ b/example/resources/langs/en.json
@@ -1,7 +1,7 @@
 {
     "title": "Hello",
     "msg": "Hello {} in the {} world ",
-    "msg_named": "Easy localization are written in the {{lang}} language",
+    "msg_named": "Easy localization are written in the {lang} language",
     "clickMe": "Click me",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/ru-RU.json
+++ b/example/resources/langs/ru-RU.json
@@ -1,7 +1,7 @@
 {
     "title": "Привет!",
     "msg": "Привет! {} добро пожаловать {} мир! ",
-    "msg_named": "Easy localization написан на языке {{lang}}",
+    "msg_named": "Easy localization написан на языке {lang}",
     "clickMe": "Нажми на меня",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/ru-RU.json
+++ b/example/resources/langs/ru-RU.json
@@ -1,6 +1,7 @@
 {
     "title": "Привет!",
     "msg": "Привет! {} добро пожаловать {} мир! ",
+    "msg_named": "Easy localization написан на языке {{lang}}",
     "clickMe": "Нажми на меня",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/ru.json
+++ b/example/resources/langs/ru.json
@@ -1,7 +1,7 @@
 {
     "title": "Привет!",
     "msg": "Привет! {} добро пожаловать {} мир! ",
-    "msg_named": "Easy localization написан на языке {{lang}}",
+    "msg_named": "Easy localization написан на языке {lang}",
     "clickMe": "Нажми на меня",
     "profile": {
         "reset_password": {

--- a/example/resources/langs/ru.json
+++ b/example/resources/langs/ru.json
@@ -1,6 +1,7 @@
 {
     "title": "Привет!",
     "msg": "Привет! {} добро пожаловать {} мир! ",
+    "msg_named": "Easy localization написан на языке {{lang}}",
     "clickMe": "Нажми на меня",
     "profile": {
         "reset_password": {

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -53,7 +53,7 @@ class Localization {
 
   String _replaceNamedArgs(String res, Map<String, String> args) {
     if(args == null || args.isEmpty) return res;
-    args.forEach((String key, String value) => res = res.replaceAll(RegExp('{{$key}}'), value));
+    args.forEach((String key, String value) => res = res.replaceAll(RegExp('{$key}'), value));
     return res;
   }
 

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -27,23 +27,18 @@ class Localization {
   }
 
   String tr(String key, {List<String> args, Map<String, String> namedArgs, String gender}) {
-    if (gender != null) return trGender(key, gender, args: args, namedArgs: namedArgs);
-    return _replaceArgs(_replaceNamedArgs(_resolve(key), namedArgs), args);
-  }
+    String res;
 
-  String trGender(
-    String key,
-    String gender, {
-    List<String> args,
-    Map<String, String> namedArgs,
-  }) =>
-      _replaceArgs(
-        _replaceNamedArgs(
-          _gender(key, gender: gender), 
-          namedArgs,
-        ),
-        args,
-      );
+    if(gender != null) {
+      res = _gender(key, gender: gender);
+    } else {
+      res = _resolve(key);
+    }
+
+    res = _replaceNamedArgs(res, namedArgs);
+
+    return _replaceArgs(res, args);
+  }
 
   String _replaceArgs(String res, List<String> args) {
     if (args == null || args.isEmpty) return res;

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -26,24 +26,34 @@ class Localization {
     return translations == null ? false : true;
   }
 
-  String tr(String key, {List<String> args, String gender}) {
-    if (gender != null) return trGender(key, gender, args: args);
-    return _replaceArgs(_resolve(key), args);
+  String tr(String key, {List<String> args, Map<String, String> namedArgs, String gender}) {
+    if (gender != null) return trGender(key, gender, args: args, namedArgs: namedArgs);
+    return _replaceArgs(_replaceNamedArgs(_resolve(key), namedArgs), args);
   }
 
   String trGender(
     String key,
     String gender, {
     List<String> args,
+    Map<String, String> namedArgs,
   }) =>
       _replaceArgs(
-        _gender(key, gender: gender),
+        _replaceNamedArgs(
+          _gender(key, gender: gender), 
+          namedArgs,
+        ),
         args,
       );
 
   String _replaceArgs(String res, List<String> args) {
     if (args == null || args.isEmpty) return res;
     args.forEach((String str) => res = res.replaceFirst(_replaceArgRegex, str));
+    return res;
+  }
+
+  String _replaceNamedArgs(String res, Map<String, String> args) {
+    if(args == null || args.isEmpty) return res;
+    args.forEach((String key, String value) => res = res.replaceAll(RegExp('{{$key}}'), value));
     return res;
   }
 

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -3,10 +3,10 @@ import 'package:intl/intl.dart';
 import 'localization.dart';
 
 String tr(String key,
-    {BuildContext context, List<String> args, String gender}) {
+    {BuildContext context, List<String> args, Map<String,String> namedArgs, String gender}) {
   return context == null
-      ? Localization.instance.tr(key, args: args, gender: gender)
-      : Localization.of(context).tr(key, args: args, gender: gender);
+      ? Localization.instance.tr(key, args: args, namedArgs: namedArgs, gender: gender)
+      : Localization.of(context).tr(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
 String plural(String key, dynamic value,

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -4,8 +4,8 @@ import 'package:intl/intl.dart';
 import 'public.dart' as ez;
 
 extension TextTranslateExtension on Text {
-  Text tr({BuildContext context, List<String> args, String gender}) =>
-      Text(ez.tr(data, context: context, args: args, gender: gender),
+  Text tr({BuildContext context, List<String> args, Map<String, String> namedArgs, String gender}) =>
+      Text(ez.tr(data, context: context, args: args, namedArgs: namedArgs, gender: gender),
           key: key,
           style: style,
           strutStyle: strutStyle,

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -142,6 +142,21 @@ void main() {
         // @TODO
       });
 
+      test('return resource and replaces named argument', () {
+        expect(
+          Localization.instance.tr('test_replace_named', namedArgs: {'arg1': 'one', 'arg2': 'two'}),
+          'test named replace one two',
+        );
+      });
+
+      test('returns resource and replaces named argument in any nest level', () {
+        expect(
+          Localization.instance
+              .tr('nested.super.duper.nested_with_named_arg', namedArgs: {'arg': 'what a nest'}),
+          'nested.super.duper.nested_with_named_arg what a nest',
+        );
+      });
+
       test('gender returns the correct resource', () {
         expect(
           Localization.instance.tr('gender', gender: 'male'),

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -11,7 +11,7 @@ class JsonAssetLoader extends AssetLoader {
       'test': 'test',
       'test_replace_one': 'test replace {}',
       'test_replace_two': 'test replace {} {}',
-      'test_replace_named': 'test named replace {{arg1}} {{arg2}}',
+      'test_replace_named': 'test named replace {arg1} {arg2}',
       'gender': {'male': 'Hi man ;)', 'female': 'Hello girl :)'},
       'gender_and_replace': {
         'male': 'Hi {} man ;)',
@@ -31,7 +31,7 @@ class JsonAssetLoader extends AssetLoader {
           'duper': {
             'nested': 'nested.super.duper.nested',
             'nested_with_arg': 'nested.super.duper.nested_with_arg {}',
-            'nested_with_named_arg': 'nested.super.duper.nested_with_named_arg {{arg}}'
+            'nested_with_named_arg': 'nested.super.duper.nested_with_named_arg {arg}'
           }
         }
       },

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -11,6 +11,7 @@ class JsonAssetLoader extends AssetLoader {
       'test': 'test',
       'test_replace_one': 'test replace {}',
       'test_replace_two': 'test replace {} {}',
+      'test_replace_named': 'test named replace {{arg1}} {{arg2}}',
       'gender': {'male': 'Hi man ;)', 'female': 'Hello girl :)'},
       'gender_and_replace': {
         'male': 'Hi {} man ;)',
@@ -29,7 +30,8 @@ class JsonAssetLoader extends AssetLoader {
         'super': {
           'duper': {
             'nested': 'nested.super.duper.nested',
-            'nested_with_arg': 'nested.super.duper.nested_with_arg {}'
+            'nested_with_arg': 'nested.super.duper.nested_with_arg {}',
+            'nested_with_named_arg': 'nested.super.duper.nested_with_named_arg {{arg}}'
           }
         }
       },


### PR DESCRIPTION
to support named arguments (resolves #88), I've added a new parameter `namedArgs1 that receives `Map<String, String>` object to replace arguments with patter like `{{key}}`.

I use double curly braces just to differentiate named arguments with regular string inside curly braces if available.

example:

`tr("named arguments {{arg1}}", namedArgs: {'arg1': 'success'})`

expected result:

`named arguments success`

I only put English example inside the example folder since I'm not familiar with the other language.