### PR TITLE
Convert Resource Stream to Broadcast Stream. Fix several runApp

### DIFF
--- a/lib/src/bloc/easy_localization_bloc.dart
+++ b/lib/src/bloc/easy_localization_bloc.dart
@@ -32,7 +32,7 @@ class _EasyLocalizationBloc {
   //
   // Stream to handle the _easyLocalizationLocale
   //
-  StreamController<Resource> _controller = StreamController<Resource>();
+  StreamController<Resource> _controller = StreamController<Resource>.broadcast();
   StreamSink<Resource> get _inSink => _controller.sink;
   Stream<Resource> get outStream => _controller.stream.transform(validate);
 
@@ -56,7 +56,7 @@ class _EasyLocalizationBloc {
   void reassemble() async {
     //recreate StreamController when hotreloaded or reloaded
     await _controller.close();
-    _controller = StreamController<Resource>();
+    _controller = StreamController<Resource>.broadcast();
   }
 
   Future _onData(Resource data) async {


### PR DESCRIPTION
Flutter support several runApp(...) calls. It may be useful to reduce init time.

Code may looks like 
```
runApp(EasyLocalization(SplashPage(...)))
if(isHaveUserData) {
   runApp(EasyLocalization(HomePage(...)))
} else {
   runApp(EasyLocalization(OnBoardingPage(...)))
}

```

However, 2.3.2 crashes with next error

>  ══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
> I/flutter (19434): The following StateError was thrown building Container(bg: Color(0xffffffff)):
> I/flutter (19434): Bad state: Stream has already been listened to.
> I/flutter (19434): 

I converted resource stream to Broadcast stream to support several listeners (it looks like the second runApp subscribes before first is disposed to unsubsribce)