### PR TITLE
Option for custom error widget on easy localisation widget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class MyApp extends StatelessWidget {
 | useOnlyLangCode  | false    | `false`                   | Trigger for using only language code for reading localization files.</br></br>Example:</br>`en.json //useOnlyLangCode: true`</br>`en-US.json //useOnlyLangCode: false`  |
 | preloaderColor   | false    | `Colors.white`            | Background color for EmptyPreloaderWidget.</br>If you use a different color background, change the color to avoid flickering |
 | preloaderWidget  | false    | `EmptyPreloaderWidget()`  | Shows your custom widget while translation is loading. |
-
+| errorWidget  | false    | `FutureErrorWidget()`  | Shows a custom error widget when an error occurs. |
 
 ## Usage
 


### PR DESCRIPTION
Add a parameter/option to add a custom error widget to the easy localisation widget. 

The custom user set widget is used when set, if no custom widget is set it will fallback to the old default widget.