### PR TITLE
Handle list of traduction

### DIFF
--- a/lib/src/translations.dart
+++ b/lib/src/translations.dart
@@ -15,7 +15,9 @@ class Translations {
     var value = _translations[kHead];
 
     for (var i = 1; i < keys.length; i++) {
-      if (value is Map<String, dynamic>) value = value[keys[i]];
+      if (value is Map<String, dynamic>)
+        value = value[keys[i]];
+      else if (value is List<dynamic>) value = value[int.parse(keys[i])];
     }
 
     cacheNestedKey(key, value);


### PR DESCRIPTION
A little modification to handle a list of traduction like flutter_localizations

Example of data: 

`
  myHome: [
            {
                "title": "MyFirstHome"
            },
            {
                "title": "MySecondHome"
            },
            {
                "title": "MyThridHome"
            }
        ]
`

Exemple of key: 'myHome.0.title'