### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ It's more easiest way change locale or get parameters 😉.
 Example:
 
 ```dart
-context.locale = Locale('en', 'US');
+context.setLocale(Locale('en', 'US'));
 
 print(context.locale.toString());
 ```


### PR DESCRIPTION
'locale' is deprecated and shouldn't be used. This is the func used in the old version of EasyLocalization. The modern func is `setLocale(val)` . This feature was deprecated after v3.0.0.