### PR TITLE
"other" as fallback plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Easy and Fast internationalization for your Flutter Apps
 ![Sponsors](https://img.shields.io/opencollective/all/flutter_easy_localization?style=flat-square)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
 
-## About this fork
-This fork serves specifically to provide a temporary fix the issue 
-[#352](https://github.com/aissat/easy_localization/issues/352) introduced on the version 3.0.0 of the official 
-[easy_localization](https://github.com/aissat/easy_localization) package.
-
 ## Why easy_localization?
 
 - 🚀 Easy translations for many languages

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Easy and Fast internationalization for your Flutter Apps
 ![Sponsors](https://img.shields.io/opencollective/all/flutter_easy_localization?style=flat-square)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
 
+## About this fork
+This fork serves specifically to provide a temporary fix the issue 
+[#352](https://github.com/aissat/easy_localization/issues/352) introduced on the version 3.0.0 of the official 
+[easy_localization](https://github.com/aissat/easy_localization) package.
+
 ## Why easy_localization?
 
 - 🚀 Easy translations for many languages

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,7 +13,6 @@ void main() async {
   await EasyLocalization.ensureInitialized();
 
   runApp(EasyLocalization(
-    child: MyApp(),
     supportedLocales: [
       Locale('en', 'US'),
       Locale('ar', 'DZ'),
@@ -21,6 +20,7 @@ void main() async {
       Locale('ru', 'RU')
     ],
     path: 'resources/langs',
+    child: MyApp(),
     // fallbackLocale: Locale('en', 'US'),
     // startLocale: Locale('de', 'DE'),
     // saveLocale: false,
@@ -87,10 +87,6 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(LocaleKeys.title).tr(),
         actions: <Widget>[
           TextButton(
-            child: Icon(
-              Icons.language,
-              color: Colors.white,
-            ),
             onPressed: () {
               Navigator.push(
                 context,
@@ -98,6 +94,10 @@ class _MyHomePageState extends State<MyHomePage> {
                     builder: (_) => LanguageView(), fullscreenDialog: true),
               );
             },
+            child: Icon(
+              Icons.language,
+              color: Colors.white,
+            ),
           ),
         ],
       ),

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -7,5 +7,16 @@
     "few": "{} few days",
     "many": "{} many days",
     "other": "{} other days"
+  },
+  "hat": {
+    "zero": "no hats",
+    "one": "one hat",
+    "two": "two hats",
+    "few": "few hats",
+    "many": "many hats",
+    "other": "other hats"
+  },
+  "hat_other": {
+    "other": "other hats"
   }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,5 +7,16 @@
     "few": "{} few days",
     "many": "{} many days",
     "other": "{} other days"
+  },
+  "hat": {
+    "zero": "no hats",
+    "one": "one hat",
+    "two": "two hats",
+    "few": "few hats",
+    "many": "many hats",
+    "other": "other hats"
+  },
+  "hat_other": {
+    "other": "other hats"
   }
 }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
-import 'plural_rules.dart';
 import 'translations.dart';
 
 class Localization {
@@ -11,8 +10,7 @@ class Localization {
   late Locale _locale;
 
   final RegExp _replaceArgRegex = RegExp(r'{}');
-  final RegExp _linkKeyMatcher =
-      RegExp(r'(?:@(?:\.[a-z]+)?:(?:[\w\-_|.]+|\([\w\-_|.]+\)))');
+  final RegExp _linkKeyMatcher = RegExp(r'(?:@(?:\.[a-z]+)?:(?:[\w\-_|.]+|\([\w\-_|.]+\)))');
   final RegExp _linkKeyPrefixMatcher = RegExp(r'^@(?:\.([a-z]+))?:');
   final RegExp _bracketsMatcher = RegExp(r'[()]');
   final _modifiers = <String, String Function(String?)>{
@@ -25,26 +23,16 @@ class Localization {
 
   static Localization? _instance;
   static Localization get instance => _instance ?? (_instance = Localization());
-  static Localization? of(BuildContext context) =>
-      Localizations.of<Localization>(context, Localization);
+  static Localization? of(BuildContext context) => Localizations.of<Localization>(context, Localization);
 
-  static bool load(
-    Locale locale, {
-    Translations? translations,
-    Translations? fallbackTranslations,
-  }) {
+  static bool load(Locale locale, {Translations? translations, Translations? fallbackTranslations}) {
     instance._locale = locale;
     instance._translations = translations;
     instance._fallbackTranslations = fallbackTranslations;
     return translations == null ? false : true;
   }
 
-  String tr(
-    String key, {
-    List<String>? args,
-    Map<String, String>? namedArgs,
-    String? gender,
-  }) {
+  String tr(String key, {List<String>? args, Map<String, String>? namedArgs, String? gender}) {
     late String res;
 
     if (gender != null) {
@@ -72,8 +60,7 @@ class Localization {
       final formatterName = linkPrefixMatches.first[1];
 
       // Remove the leading @:, @.case: and the brackets
-      final linkPlaceholder =
-          link.replaceAll(linkPrefix, '').replaceAll(_bracketsMatcher, '');
+      final linkPlaceholder = link.replaceAll(linkPrefix, '').replaceAll(_bracketsMatcher, '');
 
       var translated = _resolve(linkPlaceholder);
 
@@ -82,14 +69,13 @@ class Localization {
           translated = _modifiers[formatterName]!(translated);
         } else {
           if (logging) {
-            EasyLocalization.logger.warning(
-                'Undefined modifier $formatterName, available modifiers: ${_modifiers.keys.toString()}');
+            EasyLocalization.logger
+                .warning('Undefined modifier $formatterName, available modifiers: ${_modifiers.keys.toString()}');
           }
         }
       }
 
-      result =
-          translated.isEmpty ? result : result.replaceAll(link, translated);
+      result = translated.isEmpty ? result : result.replaceAll(link, translated);
     }
 
     return result;
@@ -103,59 +89,19 @@ class Localization {
 
   String _replaceNamedArgs(String res, Map<String, String>? args) {
     if (args == null || args.isEmpty) return res;
-    args.forEach((String key, String value) =>
-        res = res.replaceAll(RegExp('{$key}'), value));
+    args.forEach((String key, String value) => res = res.replaceAll(RegExp('{$key}'), value));
     return res;
   }
 
-  static PluralRule? _pluralRule(String? locale, num howMany) {
-    startRuleEvaluation(howMany);
-    return pluralRules[locale];
-  }
-
-  String plural(String key, num value,
-      {List<String>? args, NumberFormat? format}) {
-    late var pluralCase;
-    late var res;
-    var pluralRule = _pluralRule(_locale.languageCode, value);
-    switch (value) {
-      case 0:
-        pluralCase = PluralCase.ZERO;
-        break;
-      case 1:
-        pluralCase = PluralCase.ONE;
-        break;
-      case 2:
-        pluralCase = PluralCase.TWO;
-        break;
-      default:
-        pluralCase = pluralRule!();
-    }
-    switch (pluralCase) {
-      case PluralCase.ZERO:
-        res = _resolvePlural(key, 'zero');
-        break;
-      case PluralCase.ONE:
-        res = _resolvePlural(key, 'one');
-        break;
-      case PluralCase.TWO:
-        res = _resolvePlural(key, 'two');
-        break;
-      case PluralCase.FEW:
-        res = _resolvePlural(key, 'few');
-        break;
-      case PluralCase.MANY:
-        res = _resolvePlural(key, 'many');
-        break;
-      case PluralCase.OTHER:
-        res = _resolvePlural(key, 'other');
-        break;
-      default:
-        throw ArgumentError.value(value, 'howMany', 'Invalid plural argument');
-    }
-
-    return _replaceArgs(
-        res, args ?? [format == null ? '$value' : format.format(value)]);
+  String plural(String key, num value, {List<String>? args, NumberFormat? format}) {
+    final zero = _resolvePlural(key, 'zero');
+    final one = _resolvePlural(key, 'one');
+    final two = _resolvePlural(key, 'two');
+    final few = _resolvePlural(key, 'few');
+    final many = _resolvePlural(key, 'many');
+    final other = _resolvePlural(key, 'other');
+    final res = Intl.plural(value, locale: _locale.languageCode, zero: zero, one: one, two: two, few: few, many: many, other: other);
+    return _replaceArgs(res, args ?? [format == null ? '$value' : format.format(value)]);
   }
 
   String _gender(String key, {required String gender}) {
@@ -179,8 +125,7 @@ class Localization {
         resource = _fallbackTranslations?.get(key);
         if (resource == null) {
           if (logging) {
-            EasyLocalization.logger
-                .warning('Fallback localization key [$key] not found');
+            EasyLocalization.logger.warning('Fallback localization key [$key] not found');
           }
           return key;
         }
@@ -188,4 +133,5 @@ class Localization {
     }
     return resource;
   }
+
 }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -163,7 +163,10 @@ class Localization {
   }
 
   String _resolvePlural(String key, String subKey) {
-    var resource = _resolve('$key.$subKey');
+    final tag = '$key.$subKey';
+    var resource = _resolve(tag);
+    if (resource == tag && subKey != 'other')
+      resource = _resolve('$key.other');
     return resource;
   }
 

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -109,7 +109,10 @@ class Localization {
   }
 
   String _resolvePlural(String key, String subKey) {
-    var resource = _resolve('$key.$subKey');
+    final tag = '$key.$subKey';
+    var resource = _resolve(tag);
+    if (resource == tag && subKey != 'other')
+      resource = _resolve('$key.other');
     return resource;
   }
 
@@ -120,6 +123,7 @@ class Localization {
         EasyLocalization.logger.warning('Localization key [$key] not found');
       }
       if (_fallbackTranslations == null) {
+
         return key;
       } else {
         resource = _fallbackTranslations?.get(key);

--- a/packages/easy_logger/lib/src/logger.dart
+++ b/packages/easy_logger/lib/src/logger.dart
@@ -22,7 +22,7 @@ class EasyLogger {
     EasyLogPrinter? printer,
     this.defaultLevel = LevelMessages.info,
   }) {
-    _printer = printer ?? easyLogDefaultPrinter;
+    this.printer = printer ?? easyLogDefaultPrinter;
     _currentBuildMode = _getCurrentBuildMode();
   }
 
@@ -48,13 +48,7 @@ class EasyLogger {
   /// @Default value `LevelMessages.info`
   LevelMessages defaultLevel;
 
-  EasyLogPrinter? _printer;
-
-  /// Print function that generates and printing log lines
-  /// @Default value `easyLogDefaultPrinter`
-  EasyLogPrinter? get printer => _printer;
-
-  /// Printer function setter.
+  /// Printer function instance.
   /// You can change the standard print function to a custom one.
   /// Example:
   /// ```dart
@@ -69,7 +63,7 @@ class EasyLogger {
   ///
   /// logger.printer = customLogPrinter;
   /// ```
-  set printer(EasyLogPrinter? newPrinter) => _printer = newPrinter;
+  EasyLogPrinter? printer;
 
   BuildMode _getCurrentBuildMode() {
     if (kReleaseMode) {
@@ -95,7 +89,7 @@ class EasyLogger {
   void call(Object object, {StackTrace? stackTrace, LevelMessages? level}) {
     level ??= defaultLevel;
     if (isEnabled(level)) {
-      _printer!(object, stackTrace: stackTrace, level: level, name: name);
+      printer!(object, stackTrace: stackTrace, level: level, name: name);
     }
   }
 

--- a/test/easy_localization_context_test.dart
+++ b/test/easy_localization_context_test.dart
@@ -56,12 +56,12 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             saveLocale: false,
             useOnlyLangCode: true,
             supportedLocales: [Locale('ar')],
             fallbackLocale: Locale('ar'),
+            child: MyApp(),
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -79,7 +79,6 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             saveLocale: false,
             useOnlyLangCode: true,
@@ -87,6 +86,7 @@ void main() async {
             supportedLocales: [
               Locale('ar')
             ], // Locale('en', 'US'), Locale('ar','DZ')
+            child: MyApp(),
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -111,13 +111,13 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               // fallbackLocale:Locale('en') ,
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
+              child: MyApp(),
             ));
             // await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
@@ -134,13 +134,13 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               // fallbackLocale:Locale('en') ,
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
+              child: MyApp(),
             ));
             // await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
@@ -156,12 +156,12 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
+              child: MyApp(),
             ));
             // await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
@@ -177,13 +177,13 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: Locale('ar', 'DZ'),
+              child: MyApp(),
             ));
             // await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
@@ -203,12 +203,12 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
+              child: MyApp(),
             ));
             await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
@@ -224,13 +224,13 @@ void main() async {
         (WidgetTester tester) async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
-              child: MyApp(),
               path: 'i18n',
               supportedLocales: [
                 Locale('en', 'US'),
                 Locale('ar', 'DZ')
               ], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: Locale('ar', 'DZ'),
+              child: MyApp(),
             ));
             await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -330,7 +330,7 @@ void main() {
       });
 
       test('other as fallback', () {
-        expect(Localization.instance.plural('hat_other', -1), 'other hats');
+        expect(Localization.instance.plural('hat_other', 1), 'other hats');
       });
 
       test('with number format', () {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -307,14 +307,14 @@ void main() {
       // });
 
       test('zero', () {
-        expect(Localization.instance.plural('day', 0), '0 days');
+        expect(Localization.instance.plural('hat', 0), 'no hats');
       });
 
       test('one', () {
-        expect(Localization.instance.plural('day', 1), '1 day');
+        expect(Localization.instance.plural('hat', 1), 'one hat');
       });
       test('two', () {
-        expect(Localization.instance.plural('day', 2), '2 days');
+        expect(Localization.instance.plural('hat', 2), 'two hats');
       });
 
       test('few', () {
@@ -326,7 +326,11 @@ void main() {
       });
 
       test('other', () {
-        expect(Localization.instance.plural('day', 3), '3 other days');
+        expect(Localization.instance.plural('hat', -1), 'other hats');
+      });
+
+      test('other as fallback', () {
+        expect(Localization.instance.plural('hat_other', -1), 'other hats');
       });
 
       test('with number format', () {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -307,14 +307,14 @@ void main() {
       // });
 
       test('zero', () {
-        expect(Localization.instance.plural('day', 0), '0 days');
+        expect(Localization.instance.plural('hat', 0), 'no hats');
       });
 
       test('one', () {
-        expect(Localization.instance.plural('day', 1), '1 day');
+        expect(Localization.instance.plural('hat', 1), 'one hat');
       });
       test('two', () {
-        expect(Localization.instance.plural('day', 2), '2 days');
+        expect(Localization.instance.plural('hat', 2), 'two hats');
       });
 
       test('few', () {
@@ -326,7 +326,11 @@ void main() {
       });
 
       test('other', () {
-        expect(Localization.instance.plural('day', 3), '3 other days');
+        expect(Localization.instance.plural('hat', -1), 'other hats');
+      });
+
+      test('other as fallback', () {
+        expect(Localization.instance.plural('hat_other', 1), 'other hats');
       });
 
       test('with number format', () {

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -51,10 +51,10 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'path',
           supportedLocales: [Locale('en', 'US')],
           assetLoader: JsonAssetLoader(),
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -88,10 +88,10 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           assetLoader: RootBundleAssetLoader(),
           supportedLocales: [Locale('en', 'US')],
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -118,9 +118,9 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           supportedLocales: [Locale('en', 'US')],
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -147,9 +147,9 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18',
           supportedLocales: [Locale('en', 'US')],
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -166,9 +166,9 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           supportedLocales: [Locale('en', 'US')],
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -209,9 +209,9 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')],
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -267,9 +267,9 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')],
+          child: MyApp(),
         ));
 
         // await tester.idle();
@@ -307,14 +307,14 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           saveLocale: false,
           useOnlyLangCode: true,
           supportedLocales: [
             Locale('en'),
             Locale('ar')
-          ], // Locale('en', 'US'), Locale('ar','DZ')
+          ],
+          child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -336,14 +336,14 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           saveLocale: false,
           useOnlyLangCode: true,
           supportedLocales: [
             Locale('en'),
             Locale('ar')
-          ], // Locale('en', 'US'), Locale('ar','DZ')
+          ],
+          child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -365,12 +365,12 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           saveLocale: false,
           useOnlyLangCode: true,
           supportedLocales: [Locale('ar')],
           fallbackLocale: Locale('ar'),
+          child: MyApp(),
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -388,14 +388,14 @@ void main() async {
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
-          child: MyApp(),
           path: 'i18n',
           saveLocale: false,
           useOnlyLangCode: true,
           // fallbackLocale:Locale('en') ,
           supportedLocales: [
             Locale('ar')
-          ], // Locale('en', 'US'), Locale('ar','DZ')
+          ],
+          child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
@@ -420,10 +420,10 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             // fallbackLocale:Locale('en') ,
-            supportedLocales: [Locale('en'), Locale('ar')], //
+            supportedLocales: [Locale('en'), Locale('ar')],
+            child: MyApp(), //
           ));
           // await tester.idle();
           await tester.pump(Duration(seconds: 2));
@@ -442,10 +442,10 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             // fallbackLocale:Locale('en') ,
-            supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')], //
+            supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')],
+            child: MyApp(), //
           ));
           // await tester.idle();
           await tester.pump(Duration(seconds: 2));
@@ -464,11 +464,11 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             startLocale: Locale('ar', 'DZ'),
             // fallbackLocale:Locale('en') ,
-            supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')], //
+            supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ')],
+            child: MyApp(), //
           ));
           // await tester.idle();
           await tester.pump(Duration(seconds: 2));
@@ -497,7 +497,6 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             saveLocale: true,
             // fallbackLocale:Locale('en') ,
@@ -505,7 +504,8 @@ void main() async {
             supportedLocales: [
               Locale('en'),
               Locale('ar')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -533,14 +533,14 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             saveLocale: true,
             // fallbackLocale:Locale('en') ,
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -559,14 +559,14 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             saveLocale: false,
             // fallbackLocale:Locale('en') ,
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -593,13 +593,13 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             // fallbackLocale:Locale('en') ,
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -616,13 +616,13 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             // fallbackLocale:Locale('en') ,
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -638,12 +638,12 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -660,13 +660,13 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
             ], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: Locale('ar', 'DZ'),
+            child: MyApp(),
           ));
           // await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -686,12 +686,12 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            ],
+            child: MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
           await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
@@ -708,13 +708,13 @@ void main() async {
       (WidgetTester tester) async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
-            child: MyApp(),
             path: 'i18n',
             supportedLocales: [
               Locale('en', 'US'),
               Locale('ar', 'DZ')
             ], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: Locale('ar', 'DZ'),
+            child: MyApp(),
           ));
           await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -25,6 +25,17 @@ class JsonAssetLoader extends AssetLoader {
         'many': '{} many days',
         'other': '{} other days'
       },
+      'hat': {
+        'zero': 'no hats',
+        'one': 'one hat',
+        'two': 'two hats',
+        'few': 'few hats',
+        'many': 'many hats',
+        'other': 'other hats'
+      },
+      'hat_other': {
+        'other': 'other hats'
+      },
       'money': {
         'zero': '{} has no money',
         'one': '{} has {} dollar',


### PR DESCRIPTION
Now, when no translation is found for a specific plural, the "other" plural is used if present.
Improved plurals tests.
Related to #352 