### PR TITLE
Add option allowing skip keys of nested object

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,46 @@ Code generation supports only json files, for more information run in terminal `
 | --output-dir | -O | lib/generated | Output folder stores for the generated file |
 | --output-file | -o | codegen_loader.g.dart | Output file name |
 | --format | -f | json | Support json or keys formats |
+| --[no-]skip-object-keys | -x | false | Ignores keys defining nested object except for pluarl(), gender() keywords. See example below  |
+
+`Skip-object-keys` example
+```json
+ "generic": {
+        "username": "Username"
+    },
+    "login": {
+        "header" : {
+            "title": "title",
+            "something": "example"
+        },
+        "day": {
+            "zero":"{} дней",
+            "one": "{} день",
+            "two": "{} дня",
+            "few": "{} дня",
+            "many": "{} дней",
+            "other": "{} дней"
+        }
+    },
+```
+
+Generated keys file with enabled option `skip-object-keys`
+```dart
+static const generic_username = 'generic.username';
+static const login_header_title = 'login.header.title';
+static const login_header_someting = 'login.header.someting';
+static const login_day = 'login.day';
+```
+otherwise
+```dart
+  static const generic_username = 'generic.username';
+  static const generic = 'generic';
+  static const login_header_title = 'login.header.title';
+  static const login_header_something = 'login.header.someting';
+  static const login_header = 'login.header';
+  static const login_day = 'login.day';
+  static const login = 'login';
+```
 
 ### 🔌 Localization asset loader class
 

--- a/README.md
+++ b/README.md
@@ -131,19 +131,19 @@ class MyApp extends StatelessWidget {
 
 ### 📜 Easy localization widget properties
 
-| Properties              | Required | Default                   | Description |
-| ----------------------- | -------- | ------------------------- | ----------- |
-| key                     | false    |                           | Widget key. |
-| child                   | true     |                           | Place for your main page widget. |
-| supportedLocales        | true     |                           | List of supported locales. |
-| path                    | true     |                           | Path to your folder with localization files. |
+| Properties              | Required | Default                   | Description                                                                                                                                                                   |
+| ----------------------- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key                     | false    |                           | Widget key.                                                                                                                                                                   |
+| child                   | true     |                           | Place for your main page widget.                                                                                                                                              |
+| supportedLocales        | true     |                           | List of supported locales.                                                                                                                                                    |
+| path                    | true     |                           | Path to your folder with localization files.                                                                                                                                  |
 | assetLoader             | false    | `RootBundleAssetLoader()` | Class loader for localization files. You can use custom loaders from [Easy Localization Loader](https://github.com/aissat/easy_localization_loader) or create your own class. |
-| fallbackLocale          | false    |                           | Returns the locale when the locale is not in the list `supportedLocales`.|
-| startLocale             | false    |                           | Overrides device locale. |
-| saveLocale              | false    | `true`                    | Save locale in device storage. |
-| useFallbackTranslations | false    | `false`                   | If a localization key is not found in the locale file, try to use the fallbackLocale file.  |
-| useOnlyLangCode         | false    | `false`                   | Trigger for using only language code for reading localization files.</br></br>Example:</br>`en.json //useOnlyLangCode: true`</br>`en-US.json //useOnlyLangCode: false`  |
-| errorWidget             | false    | `FutureErrorWidget()`     | Shows a custom error widget when an error occurs. |
+| fallbackLocale          | false    |                           | Returns the locale when the locale is not in the list `supportedLocales`.                                                                                                     |
+| startLocale             | false    |                           | Overrides device locale.                                                                                                                                                      |
+| saveLocale              | false    | `true`                    | Save locale in device storage.                                                                                                                                                |
+| useFallbackTranslations | false    | `false`                   | If a localization key is not found in the locale file, try to use the fallbackLocale file.                                                                                    |
+| useOnlyLangCode         | false    | `false`                   | Trigger for using only language code for reading localization files.</br></br>Example:</br>`en.json //useOnlyLangCode: true`</br>`en-US.json //useOnlyLangCode: false`        |
+| errorWidget             | false    | `FutureErrorWidget()`     | Shows a custom error widget when an error occurs.                                                                                                                             |
 
 ## Usage
 
@@ -196,11 +196,11 @@ var title = tr('title') //Static function
 
 #### Arguments:
 
-| Name | Type | Description |
-| -------- | -------- | -------- |
-| args| `List<String>` | List of localized strings. Replaces `{}` left to right |
-| namedArgs| `Map<String, String>` | Map of localized strings. Replaces the name keys `{key_name}` according to its name |
-| gender | `String` | Gender switcher. Changes the localized string based on gender string |
+| Name      | Type                  | Description                                                                         |
+| --------- | --------------------- | ----------------------------------------------------------------------------------- |
+| args      | `List<String>`        | List of localized strings. Replaces `{}` left to right                              |
+| namedArgs | `Map<String, String>` | Map of localized strings. Replaces the name keys `{key_name}` according to its name |
+| gender    | `String`              | Gender switcher. Changes the localized string based on gender string                |
 
 Example:
 
@@ -241,11 +241,11 @@ You can use extension methods of [String] or [Text] widget, you can also use `pl
 
 #### Arguments:
 
-| Name | Type | Description |
-| -------- | -------- | -------- |
-| value| `num` | Number value for pluralization |
-| args| `List<String>` | List of localized strings. Replaces `{}` left to right |
-| format| `NumberFormat` | Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class |
+| Name   | Type           | Description                                                                                                                  |
+| ------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| value  | `num`          | Number value for pluralization                                                                                               |
+| args   | `List<String>` | List of localized strings. Replaces `{}` left to right                                                                       |
+| format | `NumberFormat` | Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class |
 
 Example:
 
@@ -416,54 +416,15 @@ Code generation supports only json files, for more information run in terminal `
 
 ### Command line arguments
 
-| Arguments | Short |  Default | Description |
-| ------ | ------ |  ------ | ------ |
-| --help | -h |  | Help info |
-| --source-dir | -S | resources/langs | Folder containing localization files |
-| --source-file | -s | First file | File to use for localization |
-| --output-dir | -O | lib/generated | Output folder stores for the generated file |
-| --output-file | -o | codegen_loader.g.dart | Output file name |
-| --format | -f | json | Support json or keys formats |
-| --[no-]skip-object-keys | -x | false | Ignores keys defining nested object except for pluarl(), gender() keywords. See example below  |
-
-`Skip-object-keys` example
-```json
- "generic": {
-        "username": "Username"
-    },
-    "login": {
-        "header" : {
-            "title": "title",
-            "something": "example"
-        },
-        "day": {
-            "zero":"{} дней",
-            "one": "{} день",
-            "two": "{} дня",
-            "few": "{} дня",
-            "many": "{} дней",
-            "other": "{} дней"
-        }
-    },
-```
-
-Generated keys file with enabled option `skip-object-keys`
-```dart
-static const generic_username = 'generic.username';
-static const login_header_title = 'login.header.title';
-static const login_header_someting = 'login.header.someting';
-static const login_day = 'login.day';
-```
-otherwise
-```dart
-  static const generic_username = 'generic.username';
-  static const generic = 'generic';
-  static const login_header_title = 'login.header.title';
-  static const login_header_something = 'login.header.someting';
-  static const login_header = 'login.header';
-  static const login_day = 'login.day';
-  static const login = 'login';
-```
+| Arguments                    | Short | Default               | Description                                                                 |
+| ---------------------------- | ----- | --------------------- | --------------------------------------------------------------------------- |
+| --help                       | -h    |                       | Help info                                                                   |
+| --source-dir                 | -S    | resources/langs       | Folder containing localization files                                        |
+| --source-file                | -s    | First file            | File to use for localization                                                |
+| --output-dir                 | -O    | lib/generated         | Output folder stores for the generated file                                 |
+| --output-file                | -o    | codegen_loader.g.dart | Output file name                                                            |
+| --format                     | -f    | json                  | Support json or keys formats                                                |
+| --[no-]skip-unnecessary-keys | -u    | false                 | Ignores keys defining nested object except for pluarl(), gender() keywords. |
 
 ### 🔌 Localization asset loader class
 
@@ -580,8 +541,8 @@ Locale('en', 'US').toStringWithSeparator(separator: '|') // en|US
 
 ## Screenshots
 
-| Arabic RTL | English LTR | Error widget |
-| ---------- | ----------- | ------------ |
+| Arabic RTL                                                                                                                  | English LTR                                                                                                                   | Error widget                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | ![Arabic RTL](https://raw.githubusercontent.com/aissat/easy_localization/master/screenshots/Screenshot_ar.png "Arabic RTL") | ![English LTR](https://raw.githubusercontent.com/aissat/easy_localization/master/screenshots/Screenshot_en.png "English LTR") | ![Error widget](https://raw.githubusercontent.com/aissat/easy_localization/master/screenshots/Screenshot_err.png "Error widget") |
 
 ## Donations

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -73,6 +73,14 @@ ArgParser _generateArgParser(GenerateOptions? generateOptions) {
       help: 'Support json or keys formats',
       allowed: ['json', 'keys']);
 
+  parser.addFlag(
+    'skip-object-keys',
+    abbr: 'x',
+    defaultsTo: false,
+    callback: (bool? x) => generateOptions!.skipObjectKeys = x,
+    help: 'If true - skip keys of nested objects.',
+  );
+
   return parser;
 }
 
@@ -83,10 +91,11 @@ class GenerateOptions {
   String? outputDir;
   String? outputFile;
   String? format;
+  bool? skipObjectKeys;
 
   @override
   String toString() {
-    return 'format: $format sourceDir: $sourceDir sourceFile: $sourceFile outputDir: $outputDir outputFile: $outputFile';
+    return 'format: $format sourceDir: $sourceDir sourceFile: $sourceFile outputDir: $outputDir outputFile: $outputFile skipObjectKeys: $skipObjectKeys';
   }
 }
 
@@ -117,7 +126,7 @@ void handleLangFiles(GenerateOptions options) async {
   }
 
   if (files.isNotEmpty) {
-    generateFile(files, outputPath, options.format);
+    generateFile(files, outputPath, options);
   } else {
     printError('Source path empty');
   }
@@ -132,8 +141,8 @@ Future<List<FileSystemEntity>> dirContents(Directory dir) {
   return completer.future;
 }
 
-void generateFile(
-    List<FileSystemEntity> files, Directory outputPath, String? format) async {
+void generateFile(List<FileSystemEntity> files, Directory outputPath,
+    GenerateOptions options) async {
   var generatedFile = File(outputPath.path);
   if (!generatedFile.existsSync()) {
     generatedFile.createSync(recursive: true);
@@ -141,12 +150,12 @@ void generateFile(
 
   var classBuilder = StringBuffer();
 
-  switch (format) {
+  switch (options.format) {
     case 'json':
       await _writeJson(classBuilder, files);
       break;
     case 'keys':
-      await _writeKeys(classBuilder, files);
+      await _writeKeys(classBuilder, files, options.skipObjectKeys);
       break;
     // case 'csv':
     //   await _writeCsv(classBuilder, files);
@@ -161,8 +170,8 @@ void generateFile(
   printInfo('All done! File generated in ${outputPath.path}');
 }
 
-Future _writeKeys(
-    StringBuffer classBuilder, List<FileSystemEntity> files) async {
+Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
+    bool? skipObjectKeys) async {
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
@@ -174,31 +183,45 @@ abstract class  LocaleKeys {
   Map<String, dynamic> translations =
       json.decode(await fileData.readAsString());
 
-  file += _resolve(translations);
+  file += _resolve(translations, skipObjectKeys);
 
   classBuilder.writeln(file);
 }
 
-String _resolve(Map<String, dynamic> translations, [String? accKey]) {
+String _resolve(Map<String, dynamic> translations, bool? skipObjectKeys,
+    [String? accKey]) {
   var fileContent = '';
 
   final sortedKeys = translations.keys.toList();
 
+  final canIgnoreKeys = skipObjectKeys != null && skipObjectKeys;
+
+  bool containsPreservedKeywords(Map<String, dynamic> map) =>
+      map.keys.any((element) => _preservedKeywords.contains(element));
+
   for (var key in sortedKeys) {
+    var ignoreKey = false;
     if (translations[key] is Map) {
+      // If key does not contain keys for plural(), gender() etc. and option is enabled -> ignore it
+      ignoreKey = !containsPreservedKeywords(
+              translations[key] as Map<String, dynamic>) &&
+          canIgnoreKeys;
+
       var nextAccKey = key;
       if (accKey != null) {
         nextAccKey = '$accKey.$key';
       }
 
-      fileContent += _resolve(translations[key], nextAccKey);
+      fileContent += _resolve(translations[key], skipObjectKeys, nextAccKey);
     }
 
     if (!_preservedKeywords.contains(key)) {
-      accKey != null
+      accKey != null && !ignoreKey
           ? fileContent +=
               '  static const ${accKey.replaceAll('.', '_')}\_$key = \'$accKey.$key\';\n'
-          : fileContent += '  static const $key = \'$key\';\n';
+          : !ignoreKey
+              ? fileContent += '  static const $key = \'$key\';\n'
+              : null;
     }
   }
 

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -171,7 +171,7 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
 }
 
 Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
-    bool? skipObjectKeys) async {
+    bool? skipUnnecessaryKeys) async {
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
@@ -183,18 +183,18 @@ abstract class  LocaleKeys {
   Map<String, dynamic> translations =
       json.decode(await fileData.readAsString());
 
-  file += _resolve(translations, skipObjectKeys);
+  file += _resolve(translations, skipUnnecessaryKeys);
 
   classBuilder.writeln(file);
 }
 
-String _resolve(Map<String, dynamic> translations, bool? skipObjectKeys,
+String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
     [String? accKey]) {
   var fileContent = '';
 
   final sortedKeys = translations.keys.toList();
 
-  final canIgnoreKeys = skipObjectKeys == true;
+  final canIgnoreKeys = skipUnnecessaryKeys == true;
 
   bool containsPreservedKeywords(Map<String, dynamic> map) =>
       map.keys.any((element) => _preservedKeywords.contains(element));
@@ -212,7 +212,8 @@ String _resolve(Map<String, dynamic> translations, bool? skipObjectKeys,
         nextAccKey = '$accKey.$key';
       }
 
-      fileContent += _resolve(translations[key], skipObjectKeys, nextAccKey);
+      fileContent +=
+          _resolve(translations[key], skipUnnecessaryKeys, nextAccKey);
     }
 
     if (!_preservedKeywords.contains(key)) {

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -74,11 +74,11 @@ ArgParser _generateArgParser(GenerateOptions? generateOptions) {
       allowed: ['json', 'keys']);
 
   parser.addFlag(
-    'skip-object-keys',
-    abbr: 'x',
+    'skip-unnecessary-keys',
+    abbr: 'u',
     defaultsTo: false,
-    callback: (bool? x) => generateOptions!.skipObjectKeys = x,
-    help: 'If true - skip keys of nested objects.',
+    callback: (bool? x) => generateOptions!.skipUnnecessaryKeys = x,
+    help: 'If true - Skip unnecessary keys of nested objects.',
   );
 
   return parser;
@@ -91,11 +91,11 @@ class GenerateOptions {
   String? outputDir;
   String? outputFile;
   String? format;
-  bool? skipObjectKeys;
+  bool? skipUnnecessaryKeys;
 
   @override
   String toString() {
-    return 'format: $format sourceDir: $sourceDir sourceFile: $sourceFile outputDir: $outputDir outputFile: $outputFile skipObjectKeys: $skipObjectKeys';
+    return 'format: $format sourceDir: $sourceDir sourceFile: $sourceFile outputDir: $outputDir outputFile: $outputFile skipUnnecessaryKeys: $skipUnnecessaryKeys';
   }
 }
 
@@ -155,7 +155,7 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
       await _writeJson(classBuilder, files);
       break;
     case 'keys':
-      await _writeKeys(classBuilder, files, options.skipObjectKeys);
+      await _writeKeys(classBuilder, files, options.skipUnnecessaryKeys);
       break;
     // case 'csv':
     //   await _writeCsv(classBuilder, files);
@@ -194,7 +194,7 @@ String _resolve(Map<String, dynamic> translations, bool? skipObjectKeys,
 
   final sortedKeys = translations.keys.toList();
 
-  final canIgnoreKeys = skipObjectKeys != null && skipObjectKeys;
+  final canIgnoreKeys = skipObjectKeys == true;
 
   bool containsPreservedKeywords(Map<String, dynamic> map) =>
       map.keys.any((element) => _preservedKeywords.contains(element));


### PR DESCRIPTION
Suppose we have the following translation JSON file

```json
{
    "generic": {
        "username": "Username"
    },
    "login": {
        "header" : {
            "title": "title",
            "someting": "sada"
        },
        "day": {
            "zero":"{} дней",
            "one": "{} день",
            "two": "{} дня",
            "few": "{} дня",
            "many": "{} дней",
            "other": "{} дней"
        }
    }
}
```

The current generator will generate the following keys structure, using `flutter pub run easy_localization:generate -S "assets/translations" -f keys -o locale_keys.g.dart`

```dart
abstract class  LocaleKeys {
  static const generic_username = 'generic.username';
  static const generic = 'generic';
  static const login_header_title = 'login.header.title';
  static const login_header_someting = 'login.header.someting';
  static const login_header = 'login.header';
  static const login_day = 'login.day';
  static const login = 'login';
}
````
Generated keys `generic`, `login` and `login_header` are not needed, as it will not provide any translation. 

This PR adds a new option to CLI enabling to **ignore** such not needed keys without breaking current behaviour for `plural()`, `gender()` functions. 

A new CLI flag is `--[no-]skip-object-keys`, abbreviation `x`.  

With this new flag, generated keys are following

```dart

abstract class  LocaleKeys {
  static const generic_username = 'generic.username';
  static const login_header_title = 'login.header.title';
  static const login_header_someting = 'login.header.someting';
  static const login_day = 'login.day';

}

```

As you can see, undesired keys are gone with preserving `login.day` for `plural()` function

I am open for any discussion, improving code quality.  
