### PR TITLE
Fixed: AssetLoader.load path parameter name

### DIFF
--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -9,7 +9,7 @@ import 'package:flutter/services.dart';
 /// ```
 ///class FileAssetLoader extends AssetLoader {
 ///  @override
-///  Future<Map<String, dynamic>> load(String path, Locale locale) async {
+///  Future<Map<String, dynamic>> load(String fullPath, Locale locale) async {
 ///    final file = File(path);
 ///    return json.decode(await file.readAsString());
 ///  }
@@ -17,7 +17,7 @@ import 'package:flutter/services.dart';
 /// ```
 abstract class AssetLoader {
   const AssetLoader();
-  Future<Map<String, dynamic>?> load(String path, Locale locale);
+  Future<Map<String, dynamic>?> load(String fullPath, Locale locale);
 }
 
 ///

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -31,9 +31,9 @@ class RootBundleAssetLoader extends AssetLoader {
   }
 
   @override
-  Future<Map<String, dynamic>?> load(String path, Locale locale) async {
-    var localePath = getLocalePath(path, locale);
-    EasyLocalization.logger.debug('Load asset from $path');
+  Future<Map<String, dynamic>?> load(String fullPath, Locale locale) async {
+    var localePath = getLocalePath(fullPath, locale);
+    EasyLocalization.logger.debug('Load asset from $fullPath');
     return json.decode(await rootBundle.loadString(localePath));
   }
 }


### PR DESCRIPTION
Loader.g.dart generates *Future<Map<String, dynamic>> load* with a parameter name different from the abstract class

![image](https://user-images.githubusercontent.com/35314270/129493483-f1898f55-5063-49cc-a547-1a4fc87ded28.png)
