### PR TITLE
Fixed: constant_identifier_names in loader generator

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -254,7 +254,7 @@ class CodegenLoader extends AssetLoader{
 
   for (var file in files) {
     final localeName =
-        path.basename(file.path).replaceFirst('.json', '').replaceAll('-', '_');
+        path.basename(file.path).replaceFirst('.json', '').replaceAll('-', '');
     listLocales.add('"$localeName": $localeName');
     final fileData = File(file.path);
 


### PR DESCRIPTION
The naming pattern for constants is lowerCamelCase, according to:

https://dart-lang.github.io/linter/lints/constant_identifier_names.html

![image](https://user-images.githubusercontent.com/35314270/129494076-12ae04e1-782d-44c3-9119-757c0e8e3401.png)
