### PR TITLE
load fallback translation data from the base language first

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,2 @@
 #https://dart.dev/guides/language/analysis-options
-include: package:pedantic/analysis_options.yaml
+#include: package:pedantic/analysis_options.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
 //import 'package:easy_localization_loader/easy_localization_loader.dart'; // import custom loaders
 import 'package:flutter/material.dart';

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -80,7 +80,14 @@ class EasyLocalizationController extends ChangeNotifier {
       data = await loadTranslationData(_locale);
       _translations = Translations(data);
       if (useFallbackTranslations && _fallbackLocale != null) {
+        Map<String, dynamic>? baseLangData;
+        if (_locale.countryCode != null && _locale.countryCode!.isNotEmpty) {
+          baseLangData = await loadTranslationData(Locale(locale.languageCode));
+        }
         data = await loadTranslationData(_fallbackLocale!);
+        if (baseLangData != null) {
+          data.addAll(baseLangData);
+        }
         _fallbackTranslations = Translations(data);
       }
     } on FlutterError catch (e) {

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -7,11 +7,11 @@ class Localization {
   Translations? _translations, _fallbackTranslations;
   late Locale _locale;
 
-  final RegExp _replaceArgRegex = RegExp(r'{}');
+  final RegExp _replaceArgRegex = RegExp('{}');
   final RegExp _linkKeyMatcher =
       RegExp(r'(?:@(?:\.[a-z]+)?:(?:[\w\-_|.]+|\([\w\-_|.]+\)))');
   final RegExp _linkKeyPrefixMatcher = RegExp(r'^@(?:\.([a-z]+))?:');
-  final RegExp _bracketsMatcher = RegExp(r'[()]');
+  final RegExp _bracketsMatcher = RegExp('[()]');
   final _modifiers = <String, String Function(String?)>{
     'upper': (String? val) => val!.toUpperCase(),
     'lower': (String? val) => val!.toLowerCase(),

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -174,10 +174,10 @@ class Localization {
   String _resolve(String key, {bool logging = true}) {
     var resource = _translations?.get(key);
     if (resource == null) {
-      if (logging) {
-        EasyLocalization.logger.warning('Localization key [$key] not found');
-      }
       if (_fallbackTranslations == null) {
+        if (logging) {
+          EasyLocalization.logger.warning('Localization key [$key] not found');
+        }
         return key;
       } else {
         resource = _fallbackTranslations?.get(key);

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -171,10 +171,10 @@ class Localization {
   String _resolve(String key, {bool logging = true}) {
     var resource = _translations?.get(key);
     if (resource == null) {
+      if (logging) {
+        EasyLocalization.logger.warning('Localization key [$key] not found');
+      }
       if (_fallbackTranslations == null) {
-        if (logging) {
-          EasyLocalization.logger.warning('Localization key [$key] not found');
-        }
         return key;
       } else {
         resource = _fallbackTranslations?.get(key);

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -1,8 +1,5 @@
-import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
-import 'package:intl/intl.dart';
 import 'plural_rules.dart';
 import 'translations.dart';
 

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:developer';
-import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_localization/src/easy_localization_controller.dart';
@@ -8,7 +7,6 @@ import 'package:easy_localization/src/localization.dart';
 import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 
 import 'utils/test_asset_loaders.dart';
 


### PR DESCRIPTION
if useFallbackTranslations is true, and the currently set locale has a countryCode, fallbackTranslations should attempt to load translation keys from the base language first, then merge them with the fallbackLocale.

Consider the following scenario:
An app supports English and Spanish languages where English is set as the fallbackLocale. Both languages contain 500 translation keys and values. However, the app needs to regionally support es-MX, but there are only a couple phrases in es-MX that differ slightly from the base Spanish language (Regístrate vs. Regístrese)

Rather than duplicating all 500 Spanish translation keys and values for es-MX, it would be much more convenient and maintainable to only have to provide the values that differ regionally and let them override the base language of that locale. 