### PR TITLE
Add namedArgs to plural()

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,13 @@ You can use extension methods of [String] or [Text] widget, you can also use `pl
 
 #### Arguments:
 
-| Name   | Type           | Description                                                                                                                  |
-| ------ | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| value  | `num`          | Number value for pluralization                                                                                               |
-| args   | `List<String>` | List of localized strings. Replaces `{}` left to right                                                                       |
-| format | `NumberFormat` | Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class |
+| Name      | Type                  | Description                                                                                                                  |
+| --------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| value     | `num`                 | Number value for pluralization                                                                                               |
+| args      | `List<String>`        | List of localized strings. Replaces `{}` left to right                                                                       |
+| namedArgs | `Map<String, String>` | Map of localized strings. Replaces the name keys `{key_name}` according to its name                                          |
+| name      | `String`              | Name of number value. Replaces `{$name}` to value                                                                            |
+| format    | `NumberFormat`        | Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class |
 
 Example:
 
@@ -270,6 +272,12 @@ Example:
     "one": "{} has {} dollar",
     "many": "{} has {} dollars",
     "other": "{} has {} dollars"
+  },
+  "money_named_args": {
+    "zero": "{name} has no money",
+    "one": "{name} has {money} dollar",
+    "many": "{name} has {money} dollars",
+    "other": "{name} has {money} dollars"
   }
 }
 ```
@@ -287,6 +295,10 @@ var money = plural('money', 10.23) // output: You have 10.23 dollars
 
 //Static function with arguments
 var money = plural('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
+
+//Static function with named arguments
+var money = plural('money_named_args', 10.23, namedArgs: {'name': 'Jane', 'money': '10.23'})  // output: Jane has 10.23 dollars
+var money = plural('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars
 ```
 
 ### 🔥 Linked translations:

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -110,8 +110,13 @@ class Localization {
     return pluralRules[locale];
   }
 
-  String plural(String key, num value,
-      {List<String>? args, NumberFormat? format}) {
+  String plural(
+    String key,
+    num value, {
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    NumberFormat? format,
+  }) {
     late var pluralCase;
     late var res;
     var pluralRule = _pluralRule(_locale.languageCode, value);
@@ -150,6 +155,8 @@ class Localization {
       default:
         throw ArgumentError.value(value, 'howMany', 'Invalid plural argument');
     }
+
+    res = _replaceNamedArgs(res, namedArgs);
 
     return _replaceArgs(
         res, args ?? [format == null ? '$value' : format.format(value)]);

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -159,12 +159,10 @@ class Localization {
 
     final formattedValue = format == null ? '$value' : format.format(value);
 
-    res = _replaceNamedArgs(
-      res,
-      name != null
-          ? {if (namedArgs != null) ...namedArgs, name: formattedValue}
-          : namedArgs,
-    );
+    if (name != null) {
+      namedArgs = {...?namedArgs, name: formattedValue};
+    }
+    res = _replaceNamedArgs(res, namedArgs);
 
     return _replaceArgs(res, args ?? [formattedValue]);
   }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -115,7 +115,7 @@ class Localization {
     num value, {
     List<String>? args,
     Map<String, String>? namedArgs,
-    String? defaultKey,
+    String? name,
     NumberFormat? format,
   }) {
     late var pluralCase;
@@ -161,8 +161,8 @@ class Localization {
 
     res = _replaceNamedArgs(
       res,
-      defaultKey != null
-          ? {if (namedArgs != null) ...namedArgs, defaultKey: formattedValue}
+      name != null
+          ? {if (namedArgs != null) ...namedArgs, name: formattedValue}
           : namedArgs,
     );
 

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -115,6 +115,7 @@ class Localization {
     num value, {
     List<String>? args,
     Map<String, String>? namedArgs,
+    String? defaultKey,
     NumberFormat? format,
   }) {
     late var pluralCase;
@@ -156,10 +157,16 @@ class Localization {
         throw ArgumentError.value(value, 'howMany', 'Invalid plural argument');
     }
 
-    res = _replaceNamedArgs(res, namedArgs);
+    final formattedValue = format == null ? '$value' : format.format(value);
 
-    return _replaceArgs(
-        res, args ?? [format == null ? '$value' : format.format(value)]);
+    res = _replaceNamedArgs(
+      res,
+      defaultKey != null
+          ? {if (namedArgs != null) ...namedArgs, defaultKey: formattedValue}
+          : namedArgs,
+    );
+
+    return _replaceArgs(res, args ?? [formattedValue]);
   }
 
   String _gender(String key, {required String gender}) {

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -45,6 +45,9 @@ String tr(
 /// [key] Localization key
 /// [value] Number value for pluralization
 /// [BuildContext] The location in the tree where this widget builds
+/// [args] List of localized strings. Replaces {} left to right
+/// [namedArgs] Map of localized strings. Replaces the name keys {key_name} according to its name
+/// [name] Name of number value. Replaces {$name} to value
 /// [format] Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class
 ///
 /// Example:
@@ -69,6 +72,12 @@ String tr(
 ///     "one": "{} has {} dollar",
 ///     "many": "{} has {} dollars",
 ///     "other": "{} has {} dollars"
+///   },
+///   "money_named_args": {
+///     "zero": "{name} has no money",
+///     "one": "{name} has {money} dollar",
+///     "many": "{name} has {money} dollars",
+///     "other": "{name} has {money} dollars"
 ///   }
 /// }
 /// ```
@@ -78,6 +87,7 @@ String tr(
 /// print('day'.plural(21)); // output: 21 день
 /// var money = plural('money', 10.23) // output: You have 10.23 dollars
 /// var money = plural('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
+/// var money = plural('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars
 /// ```
 /// {@endtemplate}
 String plural(
@@ -85,7 +95,7 @@ String plural(
   num value, {
   List<String>? args,
   Map<String, String>? namedArgs,
-  String? defaultKey,
+  String? name,
   NumberFormat? format,
 }) {
   return Localization.instance.plural(
@@ -93,7 +103,7 @@ String plural(
     value,
     args: args,
     namedArgs: namedArgs,
-    defaultKey: defaultKey,
+    name: name,
     format: format,
   );
 }

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -85,7 +85,15 @@ String plural(
   num value, {
   List<String>? args,
   Map<String, String>? namedArgs,
+  String? defaultKey,
   NumberFormat? format,
 }) {
-  return Localization.instance.plural(key, value, args: args, namedArgs: namedArgs, format: format);
+  return Localization.instance.plural(
+    key,
+    value,
+    args: args,
+    namedArgs: namedArgs,
+    defaultKey: defaultKey,
+    format: format,
+  );
 }

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -84,7 +84,8 @@ String plural(
   String key,
   num value, {
   List<String>? args,
+  Map<String, String>? namedArgs,
   NumberFormat? format,
 }) {
-  return Localization.instance.plural(key, value, args: args, format: format);
+  return Localization.instance.plural(key, value, args: args, namedArgs: namedArgs, format: format);
 }

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -41,7 +41,7 @@ extension TextTranslateExtension on Text {
     num value, {
     List<String>? args,
     Map<String, String>? namedArgs,
-    String? defaultKey,
+    String? name,
     NumberFormat? format,
   }) =>
       Text(
@@ -50,7 +50,7 @@ extension TextTranslateExtension on Text {
             value,
             args: args,
             namedArgs: namedArgs,
-            defaultKey: defaultKey,
+            name: name,
             format: format,
           ),
           key: key,
@@ -87,7 +87,7 @@ extension StringTranslateExtension on String {
     num value, {
     List<String>? args,
     Map<String, String>? namedArgs,
-    String? defaultKey,
+    String? name,
     NumberFormat? format,
   }) =>
       ez.plural(
@@ -95,7 +95,7 @@ extension StringTranslateExtension on String {
         value,
         args: args,
         namedArgs: namedArgs,
-        defaultKey: defaultKey,
+        name: name,
         format: format,
       );
 }

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -82,9 +82,10 @@ extension StringTranslateExtension on String {
   String plural(
     num value, {
     List<String>? args,
+    Map<String, String>? namedArgs,
     NumberFormat? format,
   }) =>
-      ez.plural(this, value, args: args, format: format);
+      ez.plural(this, value, args: args, namedArgs: namedArgs, format: format);
 }
 
 /// BuildContext extension method for access to [locale], [supportedLocales], [fallbackLocale], [delegates] and [deleteSaveLocale()]

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -40,6 +40,8 @@ extension TextTranslateExtension on Text {
   Text plural(
     num value, {
     List<String>? args,
+    Map<String, String>? namedArgs,
+    String? defaultKey,
     NumberFormat? format,
   }) =>
       Text(
@@ -47,6 +49,8 @@ extension TextTranslateExtension on Text {
             data ?? '',
             value,
             args: args,
+            namedArgs: namedArgs,
+            defaultKey: defaultKey,
             format: format,
           ),
           key: key,
@@ -83,9 +87,17 @@ extension StringTranslateExtension on String {
     num value, {
     List<String>? args,
     Map<String, String>? namedArgs,
+    String? defaultKey,
     NumberFormat? format,
   }) =>
-      ez.plural(this, value, args: args, namedArgs: namedArgs, format: format);
+      ez.plural(
+        this,
+        value,
+        args: args,
+        namedArgs: namedArgs,
+        defaultKey: defaultKey,
+        format: format,
+      );
 }
 
 /// BuildContext extension method for access to [locale], [supportedLocales], [fallbackLocale], [delegates] and [deleteSaveLocale()]

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -352,6 +352,30 @@ void main() {
         expect(Localization.instance.plural('money', 3, args: ['John', '3']),
             'John has 3 dollars');
       });
+
+      test('zero with named args', () {
+        expect(
+          Localization.instance.plural('money_named_args', 0,
+              namedArgs: {'name': 'John', 'money': '0'}),
+          'John has no money',
+        );
+      });
+
+      test('one with named args', () {
+        expect(
+          Localization.instance.plural('money_named_args', 1,
+              namedArgs: {'name': 'John', 'money': '1'}),
+          'John has 1 dollar',
+        );
+      });
+
+      test('other with named args', () {
+        expect(
+          Localization.instance.plural('money_named_args', 3,
+              namedArgs: {'name': 'John', 'money': '3'}),
+          'John has 3 dollars',
+        );
+      });
     });
 
     group('extensions', () {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -377,10 +377,10 @@ void main() {
         );
       });
 
-      test('named args and default key', () {
+      test('named args and value name', () {
         expect(
           Localization.instance.plural('money_named_args', 3,
-              namedArgs: {'name': 'John'}, defaultKey: 'money'),
+              namedArgs: {'name': 'John'}, valueName: 'money'),
           'John has 3 dollars',
         );
       });

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -380,7 +380,7 @@ void main() {
       test('named args and value name', () {
         expect(
           Localization.instance.plural('money_named_args', 3,
-              namedArgs: {'name': 'John'}, valueName: 'money'),
+              namedArgs: {'name': 'John'}, name: 'money'),
           'John has 3 dollars',
         );
       });

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -376,6 +376,14 @@ void main() {
           'John has 3 dollars',
         );
       });
+
+      test('named args and default key', () {
+        expect(
+          Localization.instance.plural('money_named_args', 3,
+              namedArgs: {'name': 'John'}, defaultKey: 'money'),
+          'John has 3 dollars',
+        );
+      });
     });
 
     group('extensions', () {

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -41,6 +41,11 @@ class JsonAssetLoader extends AssetLoader {
         'one': '{} has {} dollar',
         'other': '{} has {} dollars',
       },
+      'money_named_args': {
+        'zero': '{name} has no money',
+        'one': '{name} has {money} dollar',
+        'other': '{name} has {money} dollars',
+      },
       'nested_periods': {
         'Processing': 'Processing',
         'Processing.': 'Processing.',


### PR DESCRIPTION
Hi, I added `Map<String, String> namedArgs`, 'String name' parameters to `plural()` function.

Here's usage.

```json
{
  "money_named_args": {
    "zero": "{name} has no money",
    "one": "{name} has {money} dollar",
    "many": "{name} has {money} dollars",
    "other": "{name} has {money} dollars"
  },
  "songs": {
    "one": "{count} song",
    "other": "{count} songs"
  }
}
```

```dart
plural('money_named_args', 10.23, namedArgs: {'name': 'Jane', 'money': '10.23'})  // output: Jane has 10.23 dollars
plural('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars

plural('songs', 10, name: 'count')  // output: 10 songs
```

Thank you :)