### PR TITLE
Disable nested keys processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ class MyApp extends StatelessWidget {
 | useFallbackTranslations | false    | `false`                   | If a localization key is not found in the locale file, try to use the fallbackLocale file.                                                                                    |
 | useOnlyLangCode         | false    | `false`                   | Trigger for using only language code for reading localization files.</br></br>Example:</br>`en.json //useOnlyLangCode: true`</br>`en-US.json //useOnlyLangCode: false`        |
 | errorWidget             | false    | `FutureErrorWidget()`     | Shows a custom error widget when an error occurs.                                                                                                                             |
+| nestedKeysDisabled | false | `false` | Disable nested keys processing | 
 
 ## Usage
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -72,6 +72,10 @@ class EasyLocalization extends StatefulWidget {
   /// @Default value true
   final bool saveLocale;
 
+  /// Disable nested keys
+  /// @Default value false
+  final bool nestedKeysDisabled;
+
   /// Shows a custom error widget when an error is encountered instead of the default error widget.
   /// @Default value `errorWidget = ErrorWidget()`
   final Widget Function(FlutterError? message)? errorWidget;
@@ -87,6 +91,7 @@ class EasyLocalization extends StatefulWidget {
     this.useFallbackTranslations = false,
     this.assetLoader = const RootBundleAssetLoader(),
     this.saveLocale = true,
+    this.nestedKeysDisabled = false,
     this.errorWidget,
   })  : assert(supportedLocales.isNotEmpty),
         assert(path.isNotEmpty),
@@ -122,6 +127,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
     EasyLocalization.logger.debug('Init state');
     localizationController = EasyLocalizationController(
       saveLocale: widget.saveLocale,
+      nestedKeysDisabled: widget.nestedKeysDisabled,
       fallbackLocale: widget.fallbackLocale,
       supportedLocales: widget.supportedLocales,
       startLocale: widget.startLocale,

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -19,6 +19,7 @@ class EasyLocalizationController extends ChangeNotifier {
   final String path;
   final bool useFallbackTranslations;
   final bool saveLocale;
+  final bool nestedKeysDisabled;
   final bool useOnlyLangCode;
   Translations? _translations, _fallbackTranslations;
   Translations? get translations => _translations;
@@ -32,6 +33,7 @@ class EasyLocalizationController extends ChangeNotifier {
     required this.path,
     required this.useOnlyLangCode,
     required this.onLoadError,
+    required this.nestedKeysDisabled,
     Locale? startLocale,
     Locale? fallbackLocale,
     Locale? forceLocale, // used for testing
@@ -85,7 +87,10 @@ class EasyLocalizationController extends ChangeNotifier {
     Map<String, dynamic> data;
     try {
       data = await loadTranslationData(_locale);
-      _translations = Translations(data);
+      _translations = Translations(
+        data,
+        nestedKeysDisabled: nestedKeysDisabled,
+      );
       if (useFallbackTranslations && _fallbackLocale != null) {
         Map<String, dynamic>? baseLangData;
         if (_locale.countryCode != null && _locale.countryCode!.isNotEmpty) {
@@ -96,7 +101,10 @@ class EasyLocalizationController extends ChangeNotifier {
         if (baseLangData != null) {
           data.addAll(baseLangData);
         }
-        _fallbackTranslations = Translations(data);
+        _fallbackTranslations = Translations(
+          data,
+          nestedKeysDisabled: nestedKeysDisabled,
+        );
       }
     } on FlutterError catch (e) {
       onLoadError(e);

--- a/lib/src/translations.dart
+++ b/lib/src/translations.dart
@@ -1,13 +1,18 @@
 class Translations {
   final Map<String, dynamic>? _translations;
   final Map<String?, dynamic> _nestedKeysCache;
+  final bool nestedKeysDisabled;
 
-  Translations(this._translations) : _nestedKeysCache = {};
+  Translations(
+    this._translations, {
+    required this.nestedKeysDisabled,
+  }) : _nestedKeysCache = {};
   String? get(String key) {
     String? returnValue;
 
     /// Try to look it up as a nested key
-    if (isNestedKey(key)) {
+    /// if nesting is disabled don't look up
+    if (!nestedKeysDisabled && isNestedKey(key)) {
       returnValue = getNested(key);
     }
 

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -32,6 +32,7 @@ void main() {
         onLoadError: (FlutterError e) {
           log(e.toString());
         },
+        nestedKeysDisabled: false,
         assetLoader: const JsonAssetLoader());
     var r2 = EasyLocalizationController(
         forceLocale: const Locale('en', 'us'),
@@ -43,6 +44,7 @@ void main() {
           log(e.toString());
         },
         saveLocale: false,
+        nestedKeysDisabled: false,
         assetLoader: const JsonAssetLoader());
     setUpAll(() async {
       EasyLocalization.logger.enableLevels = <LevelMessages>[
@@ -179,6 +181,7 @@ void main() {
             log(e.toString());
           },
           saveLocale: false,
+          nestedKeysDisabled: false,
           assetLoader: const JsonAssetLoader());
 
       setUpAll(() async {
@@ -363,6 +366,7 @@ void main() {
             log(e.toString());
           },
           saveLocale: false,
+          nestedKeysDisabled: false,
           assetLoader: const JsonAssetLoader());
 
       setUpAll(() async {


### PR DESCRIPTION
This pull request adds an option to disable nested keys processing using `nestedKeysDisabled` property.  Currently, if the keys have `.` in them they are processed as nested keys this PR adds an option to prevent such processing. 