### PR TITLE
Don't assume asset loader returns mutable `Map`s

### DIFF
--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -94,7 +94,11 @@ class EasyLocalizationController extends ChangeNotifier {
         }
         data = await loadTranslationData(_fallbackLocale!);
         if (baseLangData != null) {
-          data.addAll(baseLangData);
+          try {
+            data.addAll(baseLangData);
+          } on UnsupportedError {
+            data = Map.of(data)..addAll(baseLangData);
+          }
         }
         _fallbackTranslations = Translations(data);
       }

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -79,6 +79,27 @@ void main() {
           true);
     });
 
+    test('merge fallbackLocale with locale without country code succeeds',
+        () async {
+      await EasyLocalizationController(
+        forceLocale: const Locale('es', 'AR'),
+        supportedLocales: const [
+          Locale('en'),
+          Locale('es'),
+          Locale('es', 'AR')
+        ],
+        path: 'path/en-us.json',
+        useOnlyLangCode: false,
+        useFallbackTranslations: true,
+        fallbackLocale: const Locale('en'),
+        onLoadError: (FlutterError e) {
+          throw e;
+        },
+        saveLocale: false,
+        assetLoader: const ImmutableJsonAssetLoader(),
+      ).loadTranslations();
+    });
+
     test('localeFromString() succeeds', () async {
       expect(const Locale('ar'), 'ar'.toLocale());
       expect(const Locale('ar', 'DZ'), 'ar_DZ'.toLocale());

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -2,6 +2,17 @@ import 'dart:ui';
 
 import 'package:easy_localization/src/asset_loader.dart';
 
+class ImmutableJsonAssetLoader extends AssetLoader {
+  const ImmutableJsonAssetLoader();
+
+  @override
+  Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
+    return Future.value(const {
+      'test': 'test',
+    });
+  }
+}
+
 class JsonAssetLoader extends AssetLoader {
   const JsonAssetLoader();
 


### PR DESCRIPTION
This PR fixes an error that can be thrown when using `useFallbackTranslations` with a locale having a country code and a `fallbackLocale`.

When trying to merge values from fallbackLocale in the locale with no country code for building fallback translations, If `UnsupportedError ` is thrown during merge, a copy of the map is built and merged.

Fixes #488.
