### PR TITLE
Add a flag to enable loading of base language translations 

### DIFF
--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -18,6 +18,7 @@ class EasyLocalizationController extends ChangeNotifier {
   final assetLoader;
   final String path;
   final bool useFallbackTranslations;
+  final bool useBaseLangTranslations;
   final bool saveLocale;
   final bool useOnlyLangCode;
   Translations? _translations, _fallbackTranslations;
@@ -27,6 +28,7 @@ class EasyLocalizationController extends ChangeNotifier {
   EasyLocalizationController({
     required List<Locale> supportedLocales,
     required this.useFallbackTranslations,
+    this.useBaseLangTranslations = false,
     required this.saveLocale,
     required this.assetLoader,
     required this.path,
@@ -88,7 +90,9 @@ class EasyLocalizationController extends ChangeNotifier {
       _translations = Translations(data);
       if (useFallbackTranslations && _fallbackLocale != null) {
         Map<String, dynamic>? baseLangData;
-        if (_locale.countryCode != null && _locale.countryCode!.isNotEmpty) {
+        if (useBaseLangTranslations &&
+            _locale.countryCode != null &&
+            _locale.countryCode!.isNotEmpty) {
           baseLangData =
               await loadBaseLangTranslationData(Locale(locale.languageCode));
         }


### PR DESCRIPTION
Reason for this PR:

- This behavior was added for a specific usecase for someone, but was enabled by default for everyone
- It causes a warning in the logs even though you're not doing anything wrong
- It causes 404 errors on web even though you're not doing anything wrong

The boolean allows the user to enable this behavior without having it enabled by default.

Let me know if you want the default value to be true for less breaking changes.