### PR TITLE
Use fallback if translation lookup returns an empty string

### DIFF
--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -187,7 +187,7 @@ class Localization {
 
   String _resolve(String key, {bool logging = true, bool fallback = true}) {
     var resource = _translations?.get(key);
-    if (resource == null) {
+    if (resource == null || resource.isEmpty) {
       if (logging) {
         EasyLocalization.logger.warning('Localization key [$key] not found');
       }


### PR DESCRIPTION
Currently, empty translation values (like `{"some_key": ""}`) do not trigger the fallback translation. This PR aims to resolve that.