### PR TITLE
fix: show fallback local at empty localization value

### DIFF
--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -87,19 +87,7 @@ class EasyLocalizationController extends ChangeNotifier {
       data = await loadTranslationData(_locale);
       _translations = Translations(data);
       if (useFallbackTranslations && _fallbackLocale != null) {
-        Map<String, dynamic>? baseLangData;
-        if (_locale.countryCode != null && _locale.countryCode!.isNotEmpty) {
-          baseLangData =
-              await loadBaseLangTranslationData(Locale(locale.languageCode));
-        }
         data = await loadTranslationData(_fallbackLocale!);
-        if (baseLangData != null) {
-          try {
-            data.addAll(baseLangData);
-          } on UnsupportedError {
-            data = Map.of(data)..addAll(baseLangData);
-          }
-        }
         _fallbackTranslations = Translations(data);
       }
     } on FlutterError catch (e) {

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -175,19 +175,19 @@ class Localization {
   }
 
   String _resolvePlural(String key, String subKey) {
-    if (subKey == 'other') return _resolve('$key.other');
+    if (subKey == 'other') return _resolve('$key.other', fallback: true);
 
     final tag = '$key.$subKey';
-    var resource = _resolve(tag, logging: false, fallback: false);
+    var resource = _resolve(tag, logging: false, fallback: true);
     if (resource == tag) {
-      resource = _resolve('$key.other');
+      resource = _resolve('$key.other', fallback: true);
     }
     return resource;
   }
 
   String _resolve(String key, {bool logging = true, bool fallback = true}) {
     var resource = _translations?.get(key);
-    if (resource == null) {
+    if (resource == null || resource.isEmpty) {
       if (logging) {
         EasyLocalization.logger.warning('Localization key [$key] not found');
       }
@@ -195,7 +195,7 @@ class Localization {
         return key;
       } else {
         resource = _fallbackTranslations?.get(key);
-        if (resource == null) {
+        if (resource == null || resource.isEmpty) {
           if (logging) {
             EasyLocalization.logger
                 .warning('Fallback localization key [$key] not found');


### PR DESCRIPTION
this PR fix the fallback strategy by including the empty translation keys in the triggers, there is a PR for that already but this PR also include handling fallback for plurals and avoid replacing fallback local keys by empty current localization keys 