### PR TITLE
trExists extension added

### DIFF
--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -206,4 +206,8 @@ class Localization {
     }
     return resource;
   }
+
+  bool exists(String key){
+    return _translations?.get(key) != null;
+  }
 }

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -41,6 +41,11 @@ String tr(
       .tr(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
+bool trExists(String key) {
+  return Localization.instance
+      .exists(key);
+}
+
 /// {@template plural}
 /// function translate with pluralization
 /// [key] Localization key

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -82,6 +82,8 @@ extension StringTranslateExtension on String {
   }) =>
       ez.tr(this, args: args, namedArgs: namedArgs, gender: gender);
 
+  bool trExists() => ez.trExists(this);
+
   /// {@macro plural}
   String plural(
     num value, {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -497,6 +497,11 @@ void main() {
           expect('test'.tr(), 'test');
         });
 
+        test('trExists', () {
+          expect('test'.trExists(), true);
+          expect('xyz'.trExists(), false);
+        });
+
         test('plural', () {
           expect('day'.plural(0), '0 days');
         });


### PR DESCRIPTION
This feature is very useful to develop custom methods to handle flavour based translations and other use cases. 

For example:
"kyc": {
    "redFlavour": "Know your customer",
    "blueFlavour": "Verify address",
    "default": "Perform KYC"
  }
  
By using trExists() extension method, we can write our own custom method to check if a translation is available for a flavour else use the default value.