### PR TITLE
Add `translate` BuildContext extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Text('title').tr() //Text widget
 print('title'.tr()); //String
 
 var title = tr('title') //Static function
+
+Text(context.tr('title')) //Extension on BuildContext
 ```
 
 #### Arguments:
@@ -292,6 +294,9 @@ print('day'.plural(21)); // output: 21 день
 
 //Static function
 var money = plural('money', 10.23) // output: You have 10.23 dollars
+
+//Text widget with plural BuildContext extension
+Text(context.plural('money', 10.23))
 
 //Static function with arguments
 var money = plural('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,8 +28,9 @@ dependencies:
   font_awesome_flutter: 9.0.0-nullsafety
 
   #custom loaders
-  easy_localization_loader:
-    git: https://github.com/aissat/easy_localization_loader.git
+#fixme(DartAndrik): Commented due to [easy_localization_loader] package dependencies issue, uncomment after resolving.
+#  easy_localization_loader:
+#    git: https://github.com/aissat/easy_localization_loader.git
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,6 @@
+class LocalizationNotFoundException implements Exception {
+  const LocalizationNotFoundException();
+
+  @override
+  String toString() => 'Localization not found for current context';
+}

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/src/localization.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
@@ -164,4 +165,24 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
 
   /// Reset locale to platform locale
   Future<void> resetLocale() => EasyLocalization.of(this)!.resetLocale();
+
+  String translate(
+    String key, {
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? gender,
+  }) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw Exception('Localization not found for current context');
+    }
+
+    return localization.tr(
+      key,
+      args: args,
+      namedArgs: namedArgs,
+      gender: gender,
+    );
+  }
 }

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/src/exceptions.dart';
 import 'package:easy_localization/src/localization.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
@@ -204,7 +205,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     final localization = Localization.of(this);
 
     if (localization == null) {
-      throw Exception('Localization not found for current context');
+      throw const LocalizationNotFoundException();
     }
 
     return localization.tr(
@@ -212,6 +213,30 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
       args: args,
       namedArgs: namedArgs,
       gender: gender,
+    );
+  }
+
+  String plural(
+    String key,
+    num number, {
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? name,
+    NumberFormat? format,
+  }) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw const LocalizationNotFoundException();
+    }
+
+    return localization.plural(
+      key,
+      number,
+      args: args,
+      namedArgs: namedArgs,
+      name: name,
+      format: format,
     );
   }
 }

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -166,6 +166,35 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
   /// Reset locale to platform locale
   Future<void> resetLocale() => EasyLocalization.of(this)!.resetLocale();
 
+  /// An extension method for translating your language keys.
+  /// Subscribes the widget on current [Localization] that provided from context.
+  /// Throws exception if [Localization] was not found.
+  ///
+  /// [key] Localization key
+  /// [args] List of localized strings. Replaces {} left to right
+  /// [namedArgs] Map of localized strings. Replaces the name keys {key_name} according to its name
+  /// [gender] Gender switcher. Changes the localized string based on gender string
+  ///
+  /// Example:
+  ///
+  /// ```json
+  /// {
+  ///    "msg":"{} are written in the {} language",
+  ///    "msg_named":"Easy localization is written in the {lang} language",
+  ///    "msg_mixed":"{} are written in the {lang} language",
+  ///    "gender":{
+  ///       "male":"Hi man ;) {}",
+  ///       "female":"Hello girl :) {}",
+  ///       "other":"Hello {}"
+  ///    }
+  /// }
+  /// ```
+  /// ```dart
+  /// Text(context.translate('msg', args: ['Easy localization', 'Dart']), // args
+  /// Text(context.translate('msg_named', namedArgs: {'lang': 'Dart'}),   // namedArgs
+  /// Text(context.translate('msg_mixed', args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
+  /// Text(context.translate('gender', gender: _gender ? "female" : "male"), // gender
+  /// ```
   String translate(
     String key, {
     List<String>? args,

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -191,12 +191,12 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
   /// }
   /// ```
   /// ```dart
-  /// Text(context.translate('msg', args: ['Easy localization', 'Dart']), // args
-  /// Text(context.translate('msg_named', namedArgs: {'lang': 'Dart'}),   // namedArgs
-  /// Text(context.translate('msg_mixed', args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
-  /// Text(context.translate('gender', gender: _gender ? "female" : "male"), // gender
+  /// Text(context.tr('msg', args: ['Easy localization', 'Dart']), // args
+  /// Text(context.tr('msg_named', namedArgs: {'lang': 'Dart'}),   // namedArgs
+  /// Text(context.tr('msg_mixed', args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
+  /// Text(context.tr('gender', gender: _gender ? "female" : "male"), // gender
   /// ```
-  String translate(
+  String tr(
     String key, {
     List<String>? args,
     Map<String, String>? namedArgs,

--- a/packages/easy_logger/lib/src/logger_printer.dart
+++ b/packages/easy_logger/lib/src/logger_printer.dart
@@ -1,51 +1,58 @@
+import 'package:flutter/foundation.dart';
+
 import '../easy_logger.dart';
 
 /// Type for function printing/logging in [EasyLogger].
 typedef EasyLogPrinter = Function(Object object,
     {String? name, LevelMessages? level, StackTrace? stackTrace});
 
-/// Default function printing.
+/// Default debug-mode function printing.
 EasyLogPrinter easyLogDefaultPrinter = (Object object,
     {String? name, StackTrace? stackTrace, LevelMessages? level}) {
-  String _coloredString(String string) {
-    switch (level) {
-      case LevelMessages.debug:
-        // gray
-        return '\u001b[90m$string\u001b[0m';
-      case LevelMessages.info:
-        // green
-        return '\u001b[32m$string\u001b[0m';
-      case LevelMessages.warning:
-        // blue
-        return '\u001B[34m$string\u001b[0m';
-      case LevelMessages.error:
-        // red
-        return '\u001b[31m$string\u001b[0m';
-      default:
-        // gray
-        return '\u001b[90m$string\u001b[0m';
+  final String levelName = level?.name != null ? '[${level?.name}] ' : '';
+  final String tag = name != null ? '[$name] ' : '';
+
+  if (kDebugMode) {
+    print(_getColoredString(level, '$tag$levelName${object.toString()}'));
+
+    if (stackTrace != null) {
+      print(_getColoredString(level, '__________________________________'));
+      print(_getColoredString(level, stackTrace.toString()));
     }
-  }
-
-  String _prepareObject() {
-    switch (level) {
-      case LevelMessages.debug:
-        return _coloredString('[$name] [DEBUG] ${object.toString()}');
-      case LevelMessages.info:
-        return _coloredString('[$name] [INFO] ${object.toString()}');
-      case LevelMessages.warning:
-        return _coloredString('[$name] [WARNING] ${object.toString()}');
-      case LevelMessages.error:
-        return _coloredString('[$name] [ERROR] ${object.toString()}');
-      default:
-        return _coloredString('[$name] ${object.toString()}');
-    }
-  }
-
-  print(_prepareObject());
-
-  if (stackTrace != null) {
-    print(_coloredString('__________________________________'));
-    print(_coloredString('${stackTrace.toString()}'));
   }
 };
+
+String _getColoredString(LevelMessages? level, String string) {
+  switch (level) {
+    case LevelMessages.debug:
+      // gray
+      return '\u001b[90m$string\u001b[0m';
+    case LevelMessages.info:
+      // green
+      return '\u001b[32m$string\u001b[0m';
+    case LevelMessages.warning:
+      // blue
+      return '\u001B[34m$string\u001b[0m';
+    case LevelMessages.error:
+      // red
+      return '\u001b[31m$string\u001b[0m';
+    default:
+      // gray
+      return '\u001b[90m$string\u001b[0m';
+  }
+}
+
+extension _LevelMessagesExtension on LevelMessages {
+  String get name {
+    switch (this) {
+      case LevelMessages.debug:
+        return 'DEBUG';
+      case LevelMessages.info:
+        return 'INFO';
+      case LevelMessages.warning:
+        return 'WARNING';
+      case LevelMessages.error:
+        return 'ERROR';
+    }
+  }
+}

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -56,7 +56,7 @@ class MyLocalizedWidget extends StatelessWidget {
   @override
   Widget build(context) {
     _context = context;
-    _contextTranslationValue = context.translate('test');
+    _contextTranslationValue = context.tr('test');
     _contextPluralValue = context.plural('day', 1);
 
     return Scaffold(


### PR DESCRIPTION
In order to close [Can't localize constant widgets](https://github.com/aissat/easy_localization/issues/433) i think that add `translate` BuildContext extension to public extensions can be the simple solution.