### PR TITLE
[fix] Small fix on Translations.get

### DIFF
--- a/lib/src/translations.dart
+++ b/lib/src/translations.dart
@@ -13,7 +13,8 @@ class Translations {
 
     /// If we failed to find the key as a nested key, then fall back
     /// to looking it up like normal.
-    returnValue ??= _translations?[key];
+    var maybeValue = _translations?[key];
+    if (maybeValue is String) returnValue ??= maybeValue;
 
     return returnValue;
   }


### PR DESCRIPTION
I got an error like this:
```
Flutter Error:  type '_Map<String, dynamic>' is not a subtype of type 'String?'
```
from `Translations.get`.
I had a JSON for translation like
```json
{
  "error": {
    "unknown": "An unknown error occurred",
    "unauthenticated": "You need to log in first"
  }
}
```
etc.

My code was trying to translate like `tr(errorString)` where `errorString` was `"error"` and this led to the lookup in [lib/src/translations.dart#L16](https://github.com/aissat/easy_localization/blob/4f87f617414e1b0ff77f793cde5736c00908e257/lib/src/translations.dart#L16) to try and put the resulting Map (
```json
{
  "unknown": "An unknown error occurred",
  "unauthenticated": "You need to log in first"
}
```
) into a String?.

This PR fixes the problem and just gives `[🌎 Easy Localization] [WARNING] Localization key [error] not found` as expected.

I did not check in any other places, if this could happen. If an error occurs somewhere else, I will open a new PR.

By the way, when will you release the next time? The last release on pub.dev was 10 months ago...?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened translation retrieval to return only text values from top-level entries, avoiding non-string data appearing in the UI. This results in more reliable localization output and reduces edge-case rendering issues when translation maps contain mixed types. Nested key lookups and caching behavior remain unchanged, preserving existing behavior while improving correctness of returned strings. No user-facing settings or workflows were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->