### PR TITLE
Ignore saved locale if it's not supported

### DIFF
--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -46,7 +46,11 @@ class EasyLocalizationController extends ChangeNotifier {
     // If saved locale then get
     else if (saveLocale && _savedLocale != null) {
       EasyLocalization.logger('Saved locale loaded ${_savedLocale.toString()}');
-      _locale = _savedLocale!;
+      _locale = selectLocaleFrom(
+        supportedLocales,
+        _savedLocale!,
+        fallbackLocale: fallbackLocale,
+      );
     } else {
       // From Device Locale
       _locale = selectLocaleFrom(

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -7,6 +7,7 @@ import 'package:easy_localization/src/localization.dart';
 import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'utils/test_asset_loaders.dart';
 
@@ -136,6 +137,52 @@ void main() {
               translations: r2.translations),
           true);
       expect(Localization.instance.tr('path'), 'path/en-us.json');
+    });
+
+    test('controller loads saved locale', () async {
+      SharedPreferences.setMockInitialValues({
+        'locale': 'en',
+      });
+      await EasyLocalization.ensureInitialized();
+      final controller = EasyLocalizationController(
+        supportedLocales: const [Locale('en'), Locale('fb')],
+        fallbackLocale: const Locale('fb'),
+        path: 'path',
+        useOnlyLangCode: true,
+        useFallbackTranslations: true,
+        onLoadError: (FlutterError e) {
+          log(e.toString());
+        },
+        saveLocale: true,
+        assetLoader: const JsonAssetLoader(),
+      );
+      expect(controller.locale, const Locale('en'));
+
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    /// E.g. if user saved a locale that was removed in a later version
+    test('controller loads fallback if saved locale is not supported',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        'locale': 'de',
+      });
+      await EasyLocalization.ensureInitialized();
+      final controller = EasyLocalizationController(
+        supportedLocales: const [Locale('en'), Locale('fb')],
+        fallbackLocale: const Locale('fb'),
+        path: 'path',
+        useOnlyLangCode: true,
+        useFallbackTranslations: true,
+        onLoadError: (FlutterError e) {
+          log(e.toString());
+        },
+        saveLocale: true,
+        assetLoader: const JsonAssetLoader(),
+      );
+      expect(controller.locale, const Locale('fb'));
+
+      SharedPreferences.setMockInitialValues({});
     });
 
     group('locale', () {


### PR DESCRIPTION
I had the following bug in a production app:

- We supported de_DE as a locale
- A user saved de_DE locally
- We decided to drop de_DE and only use de
- When the user updated, he could not start the app anylonger, because "unable to find asset de.json"

The solution is that a saved locale is not used blindly. We should validate if the locale is still supported and only use it in that case.