### PR TITLE
Fix error when base language translation data does not exist.

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -245,7 +245,7 @@ class CodegenLoader extends AssetLoader{
   const CodegenLoader();
 
   @override
-  Future<Map<String, dynamic>> load(String fullPath, Locale locale ) {
+  Future<Map<String, dynamic>?> load(String path, Locale locale) {
     return Future.value(mapLocales[locale.toString()]);
   }
 

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -84,7 +84,7 @@ class EasyLocalizationController extends ChangeNotifier {
   Future loadTranslations() async {
     Map<String, dynamic> data;
     try {
-      data = await loadTranslationData(_locale);
+      data = Map.from(await loadTranslationData(_locale));
       _translations = Translations(data);
       if (useFallbackTranslations && _fallbackLocale != null) {
         Map<String, dynamic>? baseLangData;
@@ -92,7 +92,7 @@ class EasyLocalizationController extends ChangeNotifier {
           baseLangData =
               await loadBaseLangTranslationData(Locale(locale.languageCode));
         }
-        data = await loadTranslationData(_fallbackLocale!);
+        data = Map.from(await loadTranslationData(_fallbackLocale!));
         if (baseLangData != null) {
           try {
             data.addAll(baseLangData);
@@ -120,12 +120,18 @@ class EasyLocalizationController extends ChangeNotifier {
     return null;
   }
 
-  Future loadTranslationData(Locale locale) async {
+  Future<Map<String, dynamic>> loadTranslationData(Locale locale) async {
+    late Map<String, dynamic>? data;
+
     if (useOnlyLangCode) {
-      return assetLoader.load(path, Locale(locale.languageCode));
+      data = await assetLoader.load(path, Locale(locale.languageCode));
     } else {
-      return assetLoader.load(path, locale);
+      data = await assetLoader.load(path, locale);
     }
+
+    if (data == null) return {};
+
+    return data;
   }
 
   Locale get locale => _locale;


### PR DESCRIPTION
This addresses the error found on #545

The cause of this error appears to be twofold:
1. [loadBaseLanTranslationData](https://github.com/aissat/easy_localization/blob/develop/lib/src/easy_localization_controller.dart#L123-L129) was added so that if you had locales such as `en_US` and `en_UK` it first looks for any translations that might exist under just `en`. This allows for common words between all English languages to be under the `en` locale to reduce duplicate translations (think the words stop and start).
However, loadBaseLanTranslationData calls [loadTranslationData](https://github.com/aissat/easy_localization/blob/develop/lib/src/easy_localization_controller.dart#L123-L129) and this function does not allow for null results to be returned. This is a problem since that common locale `en` may not exist and assetLoader would then be expected to return `null`.
2. The [load](https://github.com/aissat/easy_localization/blob/develop/lib/src/asset_loader.dart#L20) function under AssetLoader allows for a `null` value to be returned. However, the [load override](https://github.com/aissat/easy_localization/blob/develop/bin/generate.dart#L248-L250) for codegen_loader does not allow for a `null` value.

These commits:
- Fix codegen_loader's load function to more properly override AssetLoader's load function, allowing null results
- Allows loadTranslationData to return an empty map if the result from assetLoader is null.