### PR TITLE
Improve parsing of scriptCode in language tags

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -6,7 +6,12 @@ Locale localeFromString(String localeString) {
   final localeList = localeString.split('_');
   switch (localeList.length) {
     case 2:
-      return Locale(localeList.first, localeList.last);
+      return localeList.last.length == 4 // scriptCode length is 4
+          ? Locale.fromSubtags(
+              languageCode: localeList.first,
+              scriptCode: localeList.last,
+            )
+          : Locale(localeList.first, localeList.last);
     case 3:
       return Locale.fromSubtags(
         languageCode: localeList.first,
@@ -39,7 +44,12 @@ extension StringToLocaleHelper on String {
     final localeList = split(separator);
     switch (localeList.length) {
       case 2:
-        return Locale(localeList.first, localeList.last);
+        return localeList.last.length == 4 // scriptCode length is 4
+            ? Locale.fromSubtags(
+                languageCode: localeList.first,
+                scriptCode: localeList.last,
+              )
+            : Locale(localeList.first, localeList.last);
       case 3:
         return Locale.fromSubtags(
           languageCode: localeList.first,

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -103,6 +103,8 @@ void main() {
     test('localeFromString() succeeds', () async {
       expect(const Locale('ar'), 'ar'.toLocale());
       expect(const Locale('ar', 'DZ'), 'ar_DZ'.toLocale());
+      expect(const Locale.fromSubtags(languageCode: 'ar', scriptCode: 'Arab'),
+          'ar_Arab'.toLocale());
       expect(
           const Locale.fromSubtags(
               languageCode: 'ar', scriptCode: 'Arab', countryCode: 'DZ'),

--- a/test/easy_localization_utils_test.dart
+++ b/test/easy_localization_utils_test.dart
@@ -26,6 +26,12 @@ void main() {
         expect(locale, const Locale('en', 'US'));
       });
 
+      test('localeFromString language code and script code', () {
+        var locale = 'zh_Hant'.toLocale();
+        expect(locale,
+            const Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'));
+      });
+
       test('localeFromString language, country, script code', () {
         var locale = 'zh_Hant_HK'.toLocale();
         expect(


### PR DESCRIPTION
This PR aims to improve the parsing of `scriptCode` from locale strings. Previously, `scriptCode` was incorrectly treated as a region code.

Example:
- Previous behavior: `zh_Hant` -> language code: `zh`, region code: `Hant`
- New behavior: `zh_Hant` -> language code: `zh`, script code: `Hant`

Changes made in this PR include:
1. Updated the logic in the `toLocale` function on `StringToLocaleHelper` extension to properly parse and assign the `scriptCode`.
2. Added test cases to cover the new behavior and ensure correct parsing of locale strings with `scriptCode`.

This improvement will allow users of the library to properly handle locales with `scriptCode`, making it more versatile and accurate for different use cases.

Please let me know if you have any suggestions or concerns regarding this PR. I'm happy to make any necessary adjustments.
