### PR TITLE
Fixed bug where no text was displayed even with --help flag.

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -30,7 +30,7 @@ bool _isHelpCommand(List<String> args) {
 
 void _printHelperDisplay() {
   var parser = _generateArgParser(null);
-  stdout.write(parser.usage);
+  stdout.writeln(parser.usage);
 }
 
 GenerateOptions _generateOption(List<String> args) {
@@ -108,7 +108,7 @@ void handleLangFiles(GenerateOptions options) async {
       Directory(path.join(current.path, output.path, options.outputFile));
 
   if (!await sourcePath.exists()) {
-    stderr.write('Source path does not exist');
+    stderr.writeln('Source path does not exist');
     return;
   }
 
@@ -116,7 +116,7 @@ void handleLangFiles(GenerateOptions options) async {
   if (options.sourceFile != null) {
     final sourceFile = File(path.join(source.path, options.sourceFile));
     if (!await sourceFile.exists()) {
-      stderr.write('Source file does not exist (${sourceFile.toString()})');
+      stderr.writeln('Source file does not exist (${sourceFile.toString()})');
       return;
     }
     files = [sourceFile];
@@ -128,7 +128,7 @@ void handleLangFiles(GenerateOptions options) async {
   if (files.isNotEmpty) {
     generateFile(files, outputPath, options);
   } else {
-    stderr.write('Source path empty');
+    stderr.writeln('Source path empty');
   }
 }
 
@@ -161,13 +161,13 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
     //   await _writeCsv(classBuilder, files);
     // break;
     default:
-      stderr.write('Format not support');
+      stderr.writeln('Format not supported');
   }
 
   classBuilder.writeln('}');
   generatedFile.writeAsStringSync(classBuilder.toString());
 
-  stdout.write('All done! File generated in ${outputPath.path}');
+  stdout.writeln('All done! File generated in ${outputPath.path}');
 }
 
 Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -31,7 +30,7 @@ bool _isHelpCommand(List<String> args) {
 
 void _printHelperDisplay() {
   var parser = _generateArgParser(null);
-  log(parser.usage);
+  stdout.write(parser.usage);
 }
 
 GenerateOptions _generateOption(List<String> args) {
@@ -109,7 +108,7 @@ void handleLangFiles(GenerateOptions options) async {
       Directory(path.join(current.path, output.path, options.outputFile));
 
   if (!await sourcePath.exists()) {
-    printError('Source path does not exist');
+    stderr.write('Source path does not exist');
     return;
   }
 
@@ -117,7 +116,7 @@ void handleLangFiles(GenerateOptions options) async {
   if (options.sourceFile != null) {
     final sourceFile = File(path.join(source.path, options.sourceFile));
     if (!await sourceFile.exists()) {
-      printError('Source file does not exist (${sourceFile.toString()})');
+      stderr.write('Source file does not exist (${sourceFile.toString()})');
       return;
     }
     files = [sourceFile];
@@ -129,7 +128,7 @@ void handleLangFiles(GenerateOptions options) async {
   if (files.isNotEmpty) {
     generateFile(files, outputPath, options);
   } else {
-    printError('Source path empty');
+    stderr.write('Source path empty');
   }
 }
 
@@ -162,13 +161,13 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
     //   await _writeCsv(classBuilder, files);
     // break;
     default:
-      printError('Format not support');
+      stderr.write('Format not support');
   }
 
   classBuilder.writeln('}');
   generatedFile.writeAsStringSync(classBuilder.toString());
 
-  printInfo('All done! File generated in ${outputPath.path}');
+  stdout.write('All done! File generated in ${outputPath.path}');
 }
 
 Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
@@ -289,11 +288,3 @@ class CodegenLoader extends AssetLoader{
 //       '  static const Map<String, Map<String,dynamic>> mapLocales = \{${listLocales.join(', ')}\};');
 
 // }
-
-void printInfo(String info) {
-  log('\u001b[32measy localization: $info\u001b[0m');
-}
-
-void printError(String error) {
-  log('\u001b[31m[ERROR] easy localization: $error\u001b[0m');
-}


### PR DESCRIPTION
Previous code used `log()` from `dart:developer`. Every call is now replaced with `stdout.write()` or `stderr.write()` from `dart:io`.
This use prevented from seeing anything when running `flutter pub run easy_localization:generate -h` as suggested in the documentation.

Resolves #492 