### PR TITLE
Determine plural cases based on the actual language rules

### DIFF
--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -138,7 +138,7 @@ class Localization {
     late String res;
 
     final pluralRule = _pluralRule(_locale.languageCode, value);
-    final pluralCase = pluralRule != null ? pluralRule!() : _pluralCaseFallback(value);
+    final pluralCase = pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
 
     switch (pluralCase) {
       case PluralCase.ZERO:

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -113,6 +113,19 @@ class Localization {
     return pluralRules[locale];
   }
 
+  static PluralCase _pluralCaseFallback(num value) {
+    switch (value) {
+      case 0:
+        return PluralCase.ZERO;
+      case 1:
+        return PluralCase.ONE;
+      case 2:
+        return PluralCase.TWO;
+      default:
+        return PluralCase.OTHER;
+    }
+  }
+
   String plural(
     String key,
     num value, {
@@ -121,22 +134,12 @@ class Localization {
     String? name,
     NumberFormat? format,
   }) {
-    late PluralCase pluralCase;
+
     late String res;
-    var pluralRule = _pluralRule(_locale.languageCode, value);
-    switch (value) {
-      case 0:
-        pluralCase = PluralCase.ZERO;
-        break;
-      case 1:
-        pluralCase = PluralCase.ONE;
-        break;
-      case 2:
-        pluralCase = PluralCase.TWO;
-        break;
-      default:
-        pluralCase = pluralRule!();
-    }
+
+    final pluralRule = _pluralRule(_locale.languageCode, value);
+    final pluralCase = pluralRule != null ? pluralRule!() : _pluralCaseFallback(value);
+
     switch (pluralCase) {
       case PluralCase.ZERO:
         res = _resolvePlural(key, 'zero');

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -1,13 +1,9 @@
-import 'dart:async';
 import 'dart:developer';
 
-import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_localization/src/easy_localization_controller.dart';
 import 'package:easy_localization/src/localization.dart';
-import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'utils/test_asset_loaders.dart';
 

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+import 'dart:developer';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/src/easy_localization_controller.dart';
+import 'package:easy_localization/src/localization.dart';
+import 'package:easy_logger/easy_logger.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'utils/test_asset_loaders.dart';
+
+var printLog = [];
+
+dynamic overridePrint(Function() testFn) => () {
+      var spec = ZoneSpecification(print: (_, __, ___, String msg) {
+        // Add to log instead of printing to stdout
+        printLog.add(msg);
+      });
+      return Zone.current.fork(specification: spec).run(testFn);
+    };
+
+void main() {
+    group('language-specific-plurals', () {
+      var r = EasyLocalizationController(
+          forceLocale: const Locale('fb'),
+          supportedLocales: [const Locale('en'), const Locale('ru'), const Locale('fb')],
+          fallbackLocale: const Locale('fb'),
+          path: 'path',
+          useOnlyLangCode: true,
+          useFallbackTranslations: true,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          saveLocale: false,
+          assetLoader: const JsonAssetLoader());
+
+      setUpAll(() async {
+        await r.loadTranslations();
+        
+      });
+
+      test('english one', () async {
+        Localization.load(const Locale('en'),
+            translations: r.translations,
+            fallbackTranslations: r.fallbackTranslations);
+        expect(Localization.instance.plural('hat', 1), 'one hat');
+      }); 
+      test('english other', () async {
+        Localization.load(const Locale('en'),
+            translations: r.translations,
+            fallbackTranslations: r.fallbackTranslations);
+        expect(Localization.instance.plural('hat', 2), 'other hats');
+        expect(Localization.instance.plural('hat', 0), 'other hats');
+        expect(Localization.instance.plural('hat', 3), 'other hats');
+      }); 
+      test('russian one', () async {
+        Localization.load(const Locale('ru'),
+            translations: r.translations,
+            fallbackTranslations: r.fallbackTranslations);
+        expect(Localization.instance.plural('hat', 1), 'one hat');
+      }); 
+      test('russian few', () async {
+        Localization.load(const Locale('ru'),
+            translations: r.translations,
+            fallbackTranslations: r.fallbackTranslations);
+        expect(Localization.instance.plural('hat', 2), 'few hats');
+        expect(Localization.instance.plural('hat', 3), 'few hats');
+      });
+      test('russian many', () async {
+        Localization.load(const Locale('ru'),
+            translations: r.translations,
+            fallbackTranslations: r.fallbackTranslations);
+        expect(Localization.instance.plural('hat', 0), 'many hats');
+        expect(Localization.instance.plural('hat', 5), 'many hats');
+      });
+    });
+}

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -11,16 +11,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'utils/test_asset_loaders.dart';
 
-var printLog = [];
-
-dynamic overridePrint(Function() testFn) => () {
-      var spec = ZoneSpecification(print: (_, __, ___, String msg) {
-        // Add to log instead of printing to stdout
-        printLog.add(msg);
-      });
-      return Zone.current.fork(specification: spec).run(testFn);
-    };
-
 void main() {
     group('language-specific-plurals', () {
       var r = EasyLocalizationController(

--- a/test/easy_localization_logger_test.dart
+++ b/test/easy_localization_logger_test.dart
@@ -1,10 +1,7 @@
-import 'dart:async';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'easy_localization_test.dart';
 import 'easy_localization_utils_test.dart';
 
 void main() async {

--- a/test/easy_localization_logger_test.dart
+++ b/test/easy_localization_logger_test.dart
@@ -4,14 +4,8 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-List<String> printLog = [];
-dynamic overridePrint(Function() testFn) => () {
-      var spec = ZoneSpecification(print: (_, __, ___, String msg) {
-        // Add to log instead of printing to stdout
-        printLog.add(msg);
-      });
-      return Zone.current.fork(specification: spec).run(testFn);
-    };
+import 'easy_localization_test.dart';
+import 'easy_localization_utils_test.dart';
 
 void main() async {
   group('Logger testing', () {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:developer';
 
 import 'package:easy_localization/easy_localization.dart';

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -423,8 +423,8 @@ void main() {
 
     group('plural', () {
       var r = EasyLocalizationController(
-          forceLocale: const Locale('en'),
-          supportedLocales: const [Locale('en'), Locale('fb')],
+          forceLocale: const Locale('fb'),
+          supportedLocales: [const Locale('fb')],
           fallbackLocale: const Locale('fb'),
           path: 'path',
           useOnlyLangCode: true,
@@ -437,7 +437,7 @@ void main() {
 
       setUpAll(() async {
         await r.loadTranslations();
-        Localization.load(const Locale('en'),
+        Localization.load(const Locale('fb'),
             translations: r.translations,
             fallbackTranslations: r.fallbackTranslations);
       });

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -9,17 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'easy_localization_utils_test.dart';
 import 'utils/test_asset_loaders.dart';
-
-var printLog = [];
-
-dynamic overridePrint(Function() testFn) => () {
-      var spec = ZoneSpecification(print: (_, __, ___, String msg) {
-        // Add to log instead of printing to stdout
-        printLog.add(msg);
-      });
-      return Zone.current.fork(specification: spec).run(testFn);
-    };
 
 void main() {
   group('localization', () {

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -105,12 +105,8 @@ void main() async {
         expect(pluralFinder, findsOneWidget);
 
         expect(tr('test'), 'test');
-        expect(plural('day', 1), '1 day');
-        expect(plural('day', 2), '2 days');
-        expect(plural('day', 3), '3 other days');
 
         expect('test'.tr(), 'test');
-        expect('day'.plural(1), '1 day');
       });
     },
   );
@@ -138,9 +134,6 @@ void main() async {
         final pluralFinder = find.text('1 day');
         expect(pluralFinder, findsOneWidget);
         expect(tr('test'), 'test');
-        expect(plural('day', 1), '1 day');
-        expect(plural('day', 2), '2 days');
-        expect(plural('day', 3), '3 other days');
       });
     },
   );
@@ -168,9 +161,6 @@ void main() async {
         expect(pluralFinder, findsOneWidget);
 
         expect(tr('test'), 'test');
-        expect(plural('day', 1), '1 day');
-        expect(plural('day', 2), '2 days');
-        expect(plural('day', 3), '3 other days');
       });
     },
   );
@@ -221,9 +211,6 @@ void main() async {
         expect(pluralFinder, findsOneWidget);
 
         expect(tr('test'), 'test');
-        expect(plural('day', 1), '1 day');
-        expect(plural('day', 2), '2 days');
-        expect(plural('day', 3), '3 other days');
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         l = const Locale('ar', 'DZ');
@@ -260,9 +247,6 @@ void main() async {
         expect(pluralFinder, findsOneWidget);
 
         expect(tr('test'), 'test');
-        expect(plural('day', 1), '1 day');
-        expect(plural('day', 2), '2 days');
-        expect(plural('day', 3), '3 other days');
 
         var l = const Locale('en', 'US');
         await EasyLocalization.of(_context)!.setLocale(l);


### PR DESCRIPTION
Currently language-specific rules are ignored and all localizations are assumed to have, for example, a binary case ("two") even when it isn't needed. This breaks compatibility with localization management tools that do know which languages should have which plural cases and don't provide a way to add unneeded cases.