### PR TITLE
Pin CI flutter version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          version: "3.10.6"
+          version: "3.7.12"
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          version: "3.7.12"
+          flutter-version: "3.7.12"
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: "stable"
+          version: "3.13.9"
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          version: "3.13.9"
+          version: "3.10.6"
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: subosito/flutter-action@v2
       with:
-        version: "3.10.6"
+        version: "3.7.12"
 
     - name: Install packages dependencies
       run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,10 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: '12.x'
-    - uses: subosito/flutter-action@v1
+
+    - uses: subosito/flutter-action@v2
       with:
-        channel: 'stable'
+        version: "3.13.9"
 
     - name: Install packages dependencies
       run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: subosito/flutter-action@v2
       with:
-        version: "3.13.9"
+        version: "3.10.6"
 
     - name: Install packages dependencies
       run: flutter pub get

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: subosito/flutter-action@v2
       with:
-        version: "3.7.12"
+        flutter-version: "3.7.12"
 
     - name: Install packages dependencies
       run: flutter pub get


### PR DESCRIPTION
Recently, the CI pipeline failed because of a flutter upgrade.
I pinned it to a specific version now so we don't have to worry about upgrades