### PR TITLE
Add subLocale to easy_localization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,65 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "easy_localization",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "easy_localization (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "easy_localization (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "example (profile mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "example (release mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "easy_logger",
+            "cwd": "packages/easy_logger",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "easy_logger (profile mode)",
+            "cwd": "packages/easy_logger",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "easy_logger (release mode)",
+            "cwd": "packages/easy_logger",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/example/lib/lang_view.dart
+++ b/example/lib/lang_view.dart
@@ -36,27 +36,41 @@ class LanguageView extends StatelessWidget {
                 ),
               ),
             ),
-            _SwitchListTileMenuItem(
-                title: 'عربي',
-                subtitle: 'عربي',
-                locale:
-                    context.supportedLocales[1] //BuildContext extension method
+            _SwitchListTileMenuItem(title: 'عربي', subtitle: 'عربي', locale: context.supportedLocales[1] //BuildContext extension method
                 ),
             _Divider(),
-            _SwitchListTileMenuItem(
-                title: 'English',
-                subtitle: 'English',
-                locale: context.supportedLocales[0]),
+            _SwitchListTileMenuItem(title: 'English', subtitle: 'English', locale: context.supportedLocales[0]),
             _Divider(),
-            _SwitchListTileMenuItem(
-                title: 'German',
-                subtitle: 'German',
-                locale: context.supportedLocales[2]),
+            _SwitchListTileMenuItem(title: 'German', subtitle: 'German', locale: context.supportedLocales[2]),
             _Divider(),
-            _SwitchListTileMenuItem(
-                title: 'Русский',
-                subtitle: 'Русский',
-                locale: context.supportedLocales[3]),
+            _SwitchListTileMenuItem(title: 'Русский', subtitle: 'Русский', locale: context.supportedLocales[3]),
+            _Divider(),
+            SizedBox(
+              height: 250,
+            ),
+            Container(
+              padding: EdgeInsets.only(top: 26),
+              margin: EdgeInsets.symmetric(
+                horizontal: 24,
+              ),
+              child: Text(
+                'Choose sub language',
+                style: TextStyle(
+                  color: Colors.blue,
+                  fontFamily: 'Montserrat',
+                  fontWeight: FontWeight.w700,
+                  fontSize: 18,
+                ),
+              ),
+            ),
+            _SwitchSubListTileMenuItem(title: 'عربي', subtitle: 'عربي', subLocale: context.supportedLocales[1] //BuildContext extension method
+                ),
+            _Divider(),
+            _SwitchSubListTileMenuItem(title: 'English', subtitle: 'English', subLocale: context.supportedLocales[0]),
+            _Divider(),
+            _SwitchSubListTileMenuItem(title: 'German', subtitle: 'German', subLocale: context.supportedLocales[2]),
+            _Divider(),
+            _SwitchSubListTileMenuItem(title: 'Русский', subtitle: 'Русский', subLocale: context.supportedLocales[3]),
             _Divider(),
           ],
         ),
@@ -100,8 +114,7 @@ class _SwitchListTileMenuItem extends StatelessWidget {
     return Container(
       margin: EdgeInsets.only(left: 10, right: 10, top: 5),
       decoration: BoxDecoration(
-        border:
-            isSelected(context) ? Border.all(color: Colors.blueAccent) : null,
+        border: isSelected(context) ? Border.all(color: Colors.blueAccent) : null,
       ),
       child: ListTile(
           dense: true,
@@ -115,6 +128,45 @@ class _SwitchListTileMenuItem extends StatelessWidget {
           onTap: () async {
             log(locale.toString(), name: toString());
             await context.setLocale(locale); //BuildContext extension method
+            Navigator.pop(context);
+          }),
+    );
+  }
+}
+
+class _SwitchSubListTileMenuItem extends StatelessWidget {
+  const _SwitchSubListTileMenuItem({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    required this.subLocale,
+  }) : super(key: key);
+
+  final String title;
+  final String subtitle;
+  final Locale subLocale;
+
+  bool isSelected(BuildContext context) => subLocale == context.subLocale;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(left: 10, right: 10, top: 5),
+      decoration: BoxDecoration(
+        border: isSelected(context) ? Border.all(color: Colors.blueAccent) : null,
+      ),
+      child: ListTile(
+          dense: true,
+          // isThreeLine: true,
+          title: Text(
+            title,
+          ),
+          subtitle: Text(
+            subtitle,
+          ),
+          onTap: () async {
+            log(subLocale.toString(), name: toString());
+            await context.setSubLocale(subLocale); //BuildContext extension method
             Navigator.pop(context);
           }),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,12 +11,7 @@ void main() async {
   await EasyLocalization.ensureInitialized();
 
   runApp(EasyLocalization(
-    supportedLocales: [
-      Locale('en', 'US'),
-      Locale('ar', 'DZ'),
-      Locale('de', 'DE'),
-      Locale('ru', 'RU')
-    ],
+    supportedLocales: [Locale('en', 'US'), Locale('ar', 'DZ'), Locale('de', 'DE'), Locale('ru', 'RU')],
     path: 'resources/langs',
     child: MyApp(),
     // fallbackLocale: Locale('en', 'US'),
@@ -88,13 +83,12 @@ class _MyHomePageState extends State<MyHomePage> {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                    builder: (_) => LanguageView(), fullscreenDialog: true),
+                MaterialPageRoute(builder: (_) => LanguageView(), fullscreenDialog: true),
               );
             },
             child: Icon(
               Icons.language,
-              color: Colors.white,
+              color: Colors.black,
             ),
           ),
         ],
@@ -108,17 +102,11 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               LocaleKeys.gender_with_arg,
-              style: TextStyle(
-                  color: Colors.grey.shade600,
-                  fontSize: 19,
-                  fontWeight: FontWeight.bold),
+              style: TextStyle(color: Colors.grey.shade600, fontSize: 19, fontWeight: FontWeight.bold),
             ).tr(args: ['aissat'], gender: _gender ? 'female' : 'male'),
             Text(
               tr(LocaleKeys.gender, gender: _gender ? 'female' : 'male'),
-              style: TextStyle(
-                  color: Colors.grey.shade600,
-                  fontSize: 15,
-                  fontWeight: FontWeight.bold),
+              style: TextStyle(color: Colors.grey.shade600, fontSize: 15, fontWeight: FontWeight.bold),
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -132,8 +120,7 @@ class _MyHomePageState extends State<MyHomePage> {
               flex: 1,
             ),
             Text(LocaleKeys.msg).tr(args: ['aissat', 'Flutter']),
-            Text(LocaleKeys.msg_named)
-                .tr(namedArgs: {'lang': 'Dart'}, args: ['Easy localization']),
+            Text(LocaleKeys.msg_named).tr(namedArgs: {'lang': 'Dart'}, args: ['Easy localization']),
             Text(LocaleKeys.clicked).plural(counter),
             TextButton(
               onPressed: () {
@@ -144,14 +131,8 @@ class _MyHomePageState extends State<MyHomePage> {
             SizedBox(
               height: 15,
             ),
-            Text(
-                plural(LocaleKeys.amount, counter,
-                    format: NumberFormat.currency(
-                        locale: Intl.defaultLocale, symbol: '€')),
-                style: TextStyle(
-                    color: Colors.grey.shade900,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold)),
+            Text(plural(LocaleKeys.amount, counter, format: NumberFormat.currency(locale: Intl.defaultLocale, symbol: '€')),
+                style: TextStyle(color: Colors.grey.shade900, fontSize: 18, fontWeight: FontWeight.bold)),
             SizedBox(
               height: 20,
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -121,6 +121,8 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(LocaleKeys.msg).tr(args: ['aissat', 'Flutter']),
             Text(LocaleKeys.msg_named).tr(namedArgs: {'lang': 'Dart'}, args: ['Easy localization']),
+            Text("Sub language:"),
+            Text(LocaleKeys.msg).trSub(args: ['aissat', 'Flutter']),
             Text(LocaleKeys.clicked).plural(counter),
             TextButton(
               onPressed: () {

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -275,6 +275,9 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
     if (localizationController!.translations == null) {
       await localizationController!.loadTranslations();
     }
+    if (localizationController!.subTranslations == null) {
+      await localizationController!.loadSubTranslations();
+    }
 
     Localization.load(value, localizationController!.subLocale,
         translations: localizationController!.translations,

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -38,7 +38,7 @@ class EasyLocalization extends StatefulWidget {
   final Locale? startLocale;
 
   /// Overrides device locale.
-  final Locale? startSecondLocale;
+  final Locale? startSubLocale;
 
   /// Trigger for using only language code for reading localization files.
   /// @Default value false
@@ -75,9 +75,9 @@ class EasyLocalization extends StatefulWidget {
   /// @Default value true
   final bool saveLocale;
 
-  /// Save second locale in device storage.
+  /// Save sub locale in device storage.
   /// @Default value true
-  final bool saveSecondLocale;
+  final bool saveSubLocale;
 
   /// Shows a custom error widget when an error is encountered instead of the default error widget.
   /// @Default value `errorWidget = ErrorWidget()`
@@ -90,12 +90,12 @@ class EasyLocalization extends StatefulWidget {
     required this.path,
     this.fallbackLocale,
     this.startLocale,
-    this.startSecondLocale,
+    this.startSubLocale,
     this.useOnlyLangCode = false,
     this.useFallbackTranslations = false,
     this.assetLoader = const RootBundleAssetLoader(),
     this.saveLocale = true,
-    this.saveSecondLocale = true,
+    this.saveSubLocale = true,
     this.errorWidget,
   })  : assert(supportedLocales.isNotEmpty),
         assert(path.isNotEmpty),
@@ -129,11 +129,11 @@ class _EasyLocalizationState extends State<EasyLocalization> {
     EasyLocalization.logger.debug('Init state');
     localizationController = EasyLocalizationController(
       saveLocale: widget.saveLocale,
-      saveSecondLocale: widget.saveSecondLocale,
+      saveSubLocale: widget.saveSubLocale,
       fallbackLocale: widget.fallbackLocale,
       supportedLocales: widget.supportedLocales,
       startLocale: widget.startLocale,
-      startSecondLocale: widget.startSecondLocale,
+      startSubLocale: widget.startSubLocale,
       assetLoader: widget.assetLoader,
       useOnlyLangCode: widget.useOnlyLangCode,
       useFallbackTranslations: widget.useFallbackTranslations,
@@ -178,7 +178,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
   final EasyLocalization parent;
   final EasyLocalizationController _localeState;
   final Locale? currentLocale;
-  final Locale? currentSecondLocale;
+  final Locale? currentSubLocale;
   final _EasyLocalizationDelegate delegate;
 
   /// {@macro flutter.widgets.widgetsApp.localizationsDelegates}
@@ -205,7 +205,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   _EasyLocalizationProvider(this.parent, this._localeState, {Key? key, required this.delegate})
       : currentLocale = _localeState.locale,
-        currentSecondLocale = _localeState.secondLocale,
+        currentSubLocale = _localeState.subLocale,
         super(key: key, child: parent.child) {
     EasyLocalization.logger.debug('Init provider');
   }
@@ -213,7 +213,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
   /// Get current locale
   Locale get locale => _localeState.locale;
 
-  Locale get secondLocale => _localeState.secondLocale;
+  Locale get subLocale => _localeState.subLocale;
 
   /// Get fallback locale
   Locale? get fallbackLocale => parent.fallbackLocale;
@@ -228,11 +228,11 @@ class _EasyLocalizationProvider extends InheritedWidget {
     }
   }
 
-  Future<void> setSecondLocale(Locale secondLocale) async {
+  Future<void> setSubLocale(Locale subLocale) async {
     // Check old locale
-    if (secondLocale != _localeState.secondLocale) {
-      assert(parent.supportedLocales.contains(secondLocale));
-      await _localeState.setSecondLocale(secondLocale);
+    if (subLocale != _localeState.subLocale) {
+      assert(parent.supportedLocales.contains(subLocale));
+      await _localeState.setSubLocale(subLocale);
     }
   }
 
@@ -276,8 +276,11 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       await localizationController!.loadTranslations();
     }
 
-    Localization.load(value, localizationController!.secondLocale,
-        translations: localizationController!.translations, secondTranslations: localizationController!.secondTranslations, fallbackTranslations: localizationController!.fallbackTranslations);
+    Localization.load(value, localizationController!.subLocale,
+        translations: localizationController!.translations,
+        subTranslations: localizationController!.subTranslations,
+        fallbackTranslations: localizationController!.fallbackTranslations,
+        subFallbackTranslations: localizationController!.subFallbackTranslations);
     return Future.value(Localization.instance);
   }
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -252,10 +252,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
     return oldWidget.currentLocale != locale;
   }
 
-  static _EasyLocalizationProvider? of(BuildContext context) {
-    final widget = context.getElementForInheritedWidgetOfExactType<_EasyLocalizationProvider>()?.widget;
-    return widget is _EasyLocalizationProvider ? widget : null;
-  }
+  static _EasyLocalizationProvider? of(BuildContext context) => context.dependOnInheritedWidgetOfExactType<_EasyLocalizationProvider>();
 }
 
 class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -110,23 +110,17 @@ class EasyLocalizationController extends ChangeNotifier {
     }
   }
 
-  Future loadTranslations({Locale? localeToLoad, Locale? secondLocaleToLoad}) async {
-    await _loadTranslationsForLocale(localeToLoad ?? _locale);
-
-    await _loadTranslationsForSecondLocale(secondLocaleToLoad ?? _secondLocale);
-  }
-
-  Future _loadTranslationsForLocale(Locale locale) async {
+  Future loadTranslations() async {
     Map<String, dynamic> data;
     try {
-      data = Map.from(await loadTranslationData(locale));
+      data = Map.from(await loadTranslationData(_locale));
       _translations = Translations(data);
 
       if (useFallbackTranslations && _fallbackLocale != null) {
         Map<String, dynamic>? baseLangData;
 
-        if (locale.countryCode != null && locale.countryCode!.isNotEmpty) {
-          baseLangData = await loadBaseLangTranslationData(Locale(locale.languageCode));
+        if (_locale.countryCode != null && _locale.countryCode!.isNotEmpty) {
+          baseLangData = await loadBaseLangTranslationData(Locale(_locale.languageCode));
         }
 
         data = Map.from(await loadTranslationData(_fallbackLocale!));
@@ -146,13 +140,11 @@ class EasyLocalizationController extends ChangeNotifier {
     } catch (e) {
       onLoadError(FlutterError(e.toString()));
     }
-  }
 
-  Future _loadTranslationsForSecondLocale(Locale locale) async {
-    Map<String, dynamic> data;
+    Map<String, dynamic> secondData;
     try {
-      data = Map.from(await loadTranslationData(locale));
-      _secondTranslations = Translations(data);
+      secondData = Map.from(await loadTranslationData(_secondLocale));
+      _secondTranslations = Translations(secondData);
     } on FlutterError catch (e) {
       onLoadError(e);
     } catch (e) {
@@ -190,7 +182,7 @@ class EasyLocalizationController extends ChangeNotifier {
 
   Future<void> setLocale(Locale l) async {
     _locale = l;
-    await loadTranslations(localeToLoad: l);
+    await loadTranslations();
     notifyListeners();
     EasyLocalization.logger('Locale $locale changed');
     await _saveLocale(_locale);
@@ -198,7 +190,7 @@ class EasyLocalizationController extends ChangeNotifier {
 
   Future<void> setSecondLocale(Locale l) async {
     _secondLocale = l;
-    await loadTranslations(secondLocaleToLoad: l);
+    await loadTranslations();
     notifyListeners();
     EasyLocalization.logger('Second locale $secondLocale changed');
     await _saveSecondLocale(_secondLocale);

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -5,9 +5,9 @@ import 'plural_rules.dart';
 import 'translations.dart';
 
 class Localization {
-  Translations? _translations, _secondTranslations, _fallbackTranslations;
+  Translations? _translations, _subTranslations, _fallbackTranslations, _subFallbackTranslations;
   late Locale _locale;
-  late Locale _secondLocale;
+  late Locale _subLocale;
 
   final RegExp _replaceArgRegex = RegExp('{}');
   final RegExp _linkKeyMatcher = RegExp(r'(?:@(?:\.[a-z]+)?:(?:[\w\-_|.]+|\([\w\-_|.]+\)))');
@@ -27,17 +27,19 @@ class Localization {
 
   static bool load(
     Locale locale,
-    Locale? secondLocale, {
+    Locale? subLocale, {
     Translations? translations,
-    Translations? secondTranslations,
+    Translations? subTranslations,
     Translations? fallbackTranslations,
+    Translations? subFallbackTranslations,
   }) {
     instance._locale = locale;
     instance._translations = translations;
-    instance._secondTranslations = translations;
+    instance._subTranslations = translations;
     instance._fallbackTranslations = fallbackTranslations;
-    if (secondLocale != null) {
-      instance._secondLocale = secondLocale;
+    instance._subFallbackTranslations = subFallbackTranslations;
+    if (subLocale != null) {
+      instance._subLocale = subLocale;
     }
     return translations == null ? false : true;
   }
@@ -63,7 +65,7 @@ class Localization {
     return _replaceArgs(res, args);
   }
 
-  String trSecond(
+  String trSub(
     String key, {
     List<String>? args,
     Map<String, String>? namedArgs,
@@ -72,9 +74,9 @@ class Localization {
     late String res;
 
     if (gender != null) {
-      res = _genderSecond(key, gender: gender);
+      res = _genderSub(key, gender: gender);
     } else {
-      res = _resolveSecond(key);
+      res = _resolveSub(key);
     }
 
     res = _replaceLinks(res);
@@ -194,7 +196,7 @@ class Localization {
     return _replaceArgs(res, args ?? [formattedValue]);
   }
 
-  String pluralSecond(
+  String pluralSub(
     String key,
     num value, {
     List<String>? args,
@@ -204,27 +206,27 @@ class Localization {
   }) {
     late String res;
 
-    final pluralRule = _pluralRule(_secondLocale.languageCode, value);
+    final pluralRule = _pluralRule(_subLocale.languageCode, value);
     final pluralCase = pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
 
     switch (pluralCase) {
       case PluralCase.ZERO:
-        res = _resolvePluralSecond(key, 'zero');
+        res = _resolvePluralSub(key, 'zero');
         break;
       case PluralCase.ONE:
-        res = _resolvePluralSecond(key, 'one');
+        res = _resolvePluralSub(key, 'one');
         break;
       case PluralCase.TWO:
-        res = _resolvePluralSecond(key, 'two');
+        res = _resolvePluralSub(key, 'two');
         break;
       case PluralCase.FEW:
-        res = _resolvePluralSecond(key, 'few');
+        res = _resolvePluralSub(key, 'few');
         break;
       case PluralCase.MANY:
-        res = _resolvePluralSecond(key, 'many');
+        res = _resolvePluralSub(key, 'many');
         break;
       case PluralCase.OTHER:
-        res = _resolvePluralSecond(key, 'other');
+        res = _resolvePluralSub(key, 'other');
         break;
       default:
         throw ArgumentError.value(value, 'howMany', 'Invalid plural argument');
@@ -244,8 +246,8 @@ class Localization {
     return _resolve('$key.$gender');
   }
 
-  String _genderSecond(String key, {required String gender}) {
-    return _resolveSecond('$key.$gender');
+  String _genderSub(String key, {required String gender}) {
+    return _resolveSub('$key.$gender');
   }
 
   String _resolvePlural(String key, String subKey) {
@@ -259,13 +261,13 @@ class Localization {
     return resource;
   }
 
-  String _resolvePluralSecond(String key, String subKey) {
+  String _resolvePluralSub(String key, String subKey) {
     if (subKey == 'other') return _resolve('$key.other');
 
     final tag = '$key.$subKey';
-    var resource = _resolveSecond(tag, logging: false, fallback: _fallbackTranslations != null);
+    var resource = _resolveSub(tag, logging: false, fallback: _subFallbackTranslations != null);
     if (resource == tag) {
-      resource = _resolveSecond('$key.other');
+      resource = _resolveSub('$key.other');
     }
     return resource;
   }
@@ -291,16 +293,16 @@ class Localization {
     return resource;
   }
 
-  String _resolveSecond(String key, {bool logging = true, bool fallback = true}) {
-    var resource = _secondTranslations?.get(key);
+  String _resolveSub(String key, {bool logging = true, bool fallback = true}) {
+    var resource = _subTranslations?.get(key);
     if (resource == null) {
       if (logging) {
         EasyLocalization.logger.warning('Localization key [$key] not found');
       }
-      if (_fallbackTranslations == null || !fallback) {
+      if (_subFallbackTranslations == null || !fallback) {
         return key;
       } else {
-        resource = _fallbackTranslations?.get(key);
+        resource = _subFallbackTranslations?.get(key);
         if (resource == null) {
           if (logging) {
             EasyLocalization.logger.warning('Fallback localization key [$key] not found');
@@ -316,7 +318,7 @@ class Localization {
     return _translations?.get(key) != null;
   }
 
-  bool existsSecond(String key) {
-    return _secondTranslations?.get(key) != null;
+  bool existsSub(String key) {
+    return _subTranslations?.get(key) != null;
   }
 }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -74,7 +74,7 @@ class Localization {
     if (gender != null) {
       res = _gender(key, gender: gender);
     } else {
-      res = _resolve(key);
+      res = _secondResolve(key);
     }
 
     res = _replaceLinks(res);
@@ -257,6 +257,27 @@ class Localization {
 
   String _resolve(String key, {bool logging = true, bool fallback = true}) {
     var resource = _translations?.get(key);
+    if (resource == null) {
+      if (logging) {
+        EasyLocalization.logger.warning('Localization key [$key] not found');
+      }
+      if (_fallbackTranslations == null || !fallback) {
+        return key;
+      } else {
+        resource = _fallbackTranslations?.get(key);
+        if (resource == null) {
+          if (logging) {
+            EasyLocalization.logger.warning('Fallback localization key [$key] not found');
+          }
+          return key;
+        }
+      }
+    }
+    return resource;
+  }
+
+  String _secondResolve(String key, {bool logging = true, bool fallback = true}) {
+    var resource = _secondTranslations?.get(key);
     if (resource == null) {
       if (logging) {
         EasyLocalization.logger.warning('Localization key [$key] not found');

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -35,7 +35,7 @@ class Localization {
   }) {
     instance._locale = locale;
     instance._translations = translations;
-    instance._subTranslations = translations;
+    instance._subTranslations = subTranslations;
     instance._fallbackTranslations = fallbackTranslations;
     instance._subFallbackTranslations = subFallbackTranslations;
     if (subLocale != null) {

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -72,9 +72,9 @@ class Localization {
     late String res;
 
     if (gender != null) {
-      res = _gender(key, gender: gender);
+      res = _genderSecond(key, gender: gender);
     } else {
-      res = _secondResolve(key);
+      res = _resolveSecond(key);
     }
 
     res = _replaceLinks(res);
@@ -209,22 +209,22 @@ class Localization {
 
     switch (pluralCase) {
       case PluralCase.ZERO:
-        res = _resolvePlural(key, 'zero');
+        res = _resolvePluralSecond(key, 'zero');
         break;
       case PluralCase.ONE:
-        res = _resolvePlural(key, 'one');
+        res = _resolvePluralSecond(key, 'one');
         break;
       case PluralCase.TWO:
-        res = _resolvePlural(key, 'two');
+        res = _resolvePluralSecond(key, 'two');
         break;
       case PluralCase.FEW:
-        res = _resolvePlural(key, 'few');
+        res = _resolvePluralSecond(key, 'few');
         break;
       case PluralCase.MANY:
-        res = _resolvePlural(key, 'many');
+        res = _resolvePluralSecond(key, 'many');
         break;
       case PluralCase.OTHER:
-        res = _resolvePlural(key, 'other');
+        res = _resolvePluralSecond(key, 'other');
         break;
       default:
         throw ArgumentError.value(value, 'howMany', 'Invalid plural argument');
@@ -244,6 +244,10 @@ class Localization {
     return _resolve('$key.$gender');
   }
 
+  String _genderSecond(String key, {required String gender}) {
+    return _resolveSecond('$key.$gender');
+  }
+
   String _resolvePlural(String key, String subKey) {
     if (subKey == 'other') return _resolve('$key.other');
 
@@ -251,6 +255,17 @@ class Localization {
     var resource = _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
     if (resource == tag) {
       resource = _resolve('$key.other');
+    }
+    return resource;
+  }
+
+  String _resolvePluralSecond(String key, String subKey) {
+    if (subKey == 'other') return _resolve('$key.other');
+
+    final tag = '$key.$subKey';
+    var resource = _resolveSecond(tag, logging: false, fallback: _fallbackTranslations != null);
+    if (resource == tag) {
+      resource = _resolveSecond('$key.other');
     }
     return resource;
   }
@@ -276,7 +291,7 @@ class Localization {
     return resource;
   }
 
-  String _secondResolve(String key, {bool logging = true, bool fallback = true}) {
+  String _resolveSecond(String key, {bool logging = true, bool fallback = true}) {
     var resource = _secondTranslations?.get(key);
     if (resource == null) {
       if (logging) {

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -38,16 +38,56 @@ String tr(
   Map<String, String>? namedArgs,
   String? gender,
 }) {
-  return context != null
-      ? Localization.of(context)!
-          .tr(key, args: args, namedArgs: namedArgs, gender: gender)
-      : Localization.instance
-          .tr(key, args: args, namedArgs: namedArgs, gender: gender);
+  return context != null ? Localization.of(context)!.tr(key, args: args, namedArgs: namedArgs, gender: gender) : Localization.instance.tr(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
 bool trExists(String key) {
-  return Localization.instance
-      .exists(key);
+  return Localization.instance.exists(key);
+}
+
+/// {@template trSecond}
+/// Main function for translate your language keys
+/// [key] Localization key
+/// [BuildContext] The location in the tree where this widget builds
+/// [args] List of localized strings. Replaces {} left to right
+/// [namedArgs] Map of localized strings. Replaces the name keys {key_name} according to its name
+/// [gender] Gender switcher. Changes the localized string based on gender string
+///
+/// Example:
+///
+/// ```json
+/// {
+///    "msg":"{} are written in the {} language",
+///    "msg_named":"Easy localization is written in the {lang} language",
+///    "msg_mixed":"{} are written in the {lang} language",
+///    "gender":{
+///       "male":"Hi man ;) {}",
+///       "female":"Hello girl :) {}",
+///       "other":"Hello {}"
+///    }
+/// }
+/// ```
+/// ```dart
+/// Text('msg').trSecond(args: ['Easy localization', 'Dart']), // args
+/// Text('msg_named').trSecond(namedArgs: {'lang': 'Dart'}),   // namedArgs
+/// Text('msg_mixed').trSecond(args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
+/// Text('gender').trSecond(gender: _gender ? "female" : "male"), // gender
+/// ```
+/// {@endtemplate}
+String trSecond(
+  String key, {
+  BuildContext? context,
+  List<String>? args,
+  Map<String, String>? namedArgs,
+  String? gender,
+}) {
+  return context != null
+      ? Localization.of(context)!.trSecond(key, args: args, namedArgs: namedArgs, gender: gender)
+      : Localization.instance.trSecond(key, args: args, namedArgs: namedArgs, gender: gender);
+}
+
+bool trSecondExists(String key) {
+  return Localization.instance.existsSecond(key);
 }
 
 /// {@template plural}
@@ -110,8 +150,70 @@ String plural(
   NumberFormat? format,
 }) {
   return context != null
-      ? Localization.of(context)!.plural(key, value,
-          args: args, namedArgs: namedArgs, name: name, format: format)
-      : Localization.instance.plural(key, value,
-          args: args, namedArgs: namedArgs, name: name, format: format);
+      ? Localization.of(context)!.plural(key, value, args: args, namedArgs: namedArgs, name: name, format: format)
+      : Localization.instance.plural(key, value, args: args, namedArgs: namedArgs, name: name, format: format);
+}
+
+/// {@template plural}
+/// function translate with pluralization
+/// [key] Localization key
+/// [value] Number value for pluralization
+/// [BuildContext] The location in the tree where this widget builds
+/// [args] List of localized strings. Replaces {} left to right
+/// [namedArgs] Map of localized strings. Replaces the name keys {key_name} according to its name
+/// [name] Name of number value. Replaces {$name} to value
+/// [format] Formats a numeric value using a [NumberFormat](https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html) class
+///
+/// Example:
+///```json
+/// {
+///   "day": {
+///     "zero":"{} дней",
+///     "one": "{} день",
+///     "two": "{} дня",
+///     "few": "{} дня",
+///     "many": "{} дней",
+///     "other": "{} дней"
+///   },
+///   "money": {
+///     "zero": "You not have money",
+///     "one": "You have {} dollar",
+///     "many": "You have {} dollars",
+///     "other": "You have {} dollars"
+///   },
+///   "money_args": {
+///     "zero": "{} has no money",
+///     "one": "{} has {} dollar",
+///     "many": "{} has {} dollars",
+///     "other": "{} has {} dollars"
+///   },
+///   "money_named_args": {
+///     "zero": "{name} has no money",
+///     "one": "{name} has {money} dollar",
+///     "many": "{name} has {money} dollars",
+///     "other": "{name} has {money} dollars"
+///   }
+/// }
+/// ```
+///
+///```dart
+/// Text('money').pluralSecond(1000000, format: NumberFormat.compact(locale: context.locale.toString())) // output: You have 1M dollars
+/// print('day'.pluralSecond(21)); // output: 21 день
+/// var money = pluralSecond('money', 10.23) // output: You have 10.23 dollars
+/// var money = pluralSecond('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
+/// var money = pluralSecond('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars
+/// ```
+/// {@endtemplate}
+String pluralSecond(
+  String key,
+  num value, {
+  List<String>? args,
+  BuildContext? context,
+  Map<String, String>? namedArgs,
+  String? name,
+  NumberFormat? format,
+}) {
+  return context != null
+      ? Localization.of(context)!.pluralSecond(key, value, args: args, namedArgs: namedArgs, name: name, format: format)
+      : Localization.instance.pluralSecond(key, value, args: args, namedArgs: namedArgs, name: name, format: format);
 }

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -45,7 +45,7 @@ bool trExists(String key) {
   return Localization.instance.exists(key);
 }
 
-/// {@template trSecond}
+/// {@template trSub}
 /// Main function for translate your language keys
 /// [key] Localization key
 /// [BuildContext] The location in the tree where this widget builds
@@ -68,26 +68,24 @@ bool trExists(String key) {
 /// }
 /// ```
 /// ```dart
-/// Text('msg').trSecond(args: ['Easy localization', 'Dart']), // args
-/// Text('msg_named').trSecond(namedArgs: {'lang': 'Dart'}),   // namedArgs
-/// Text('msg_mixed').trSecond(args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
-/// Text('gender').trSecond(gender: _gender ? "female" : "male"), // gender
+/// Text('msg').trSub(args: ['Easy localization', 'Dart']), // args
+/// Text('msg_named').trSub(namedArgs: {'lang': 'Dart'}),   // namedArgs
+/// Text('msg_mixed').trSub(args: ['Easy localization'], namedArgs: {'lang': 'Dart'}), // args and namedArgs
+/// Text('gender').trSub(gender: _gender ? "female" : "male"), // gender
 /// ```
 /// {@endtemplate}
-String trSecond(
+String trSub(
   String key, {
   BuildContext? context,
   List<String>? args,
   Map<String, String>? namedArgs,
   String? gender,
 }) {
-  return context != null
-      ? Localization.of(context)!.trSecond(key, args: args, namedArgs: namedArgs, gender: gender)
-      : Localization.instance.trSecond(key, args: args, namedArgs: namedArgs, gender: gender);
+  return context != null ? Localization.of(context)!.trSub(key, args: args, namedArgs: namedArgs, gender: gender) : Localization.instance.trSub(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
-bool trSecondExists(String key) {
-  return Localization.instance.existsSecond(key);
+bool trSubExists(String key) {
+  return Localization.instance.existsSub(key);
 }
 
 /// {@template plural}
@@ -154,7 +152,7 @@ String plural(
       : Localization.instance.plural(key, value, args: args, namedArgs: namedArgs, name: name, format: format);
 }
 
-/// {@template plural}
+/// {@template pluralSub}
 /// function translate with pluralization
 /// [key] Localization key
 /// [value] Number value for pluralization
@@ -197,14 +195,14 @@ String plural(
 /// ```
 ///
 ///```dart
-/// Text('money').pluralSecond(1000000, format: NumberFormat.compact(locale: context.locale.toString())) // output: You have 1M dollars
-/// print('day'.pluralSecond(21)); // output: 21 день
-/// var money = pluralSecond('money', 10.23) // output: You have 10.23 dollars
-/// var money = pluralSecond('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
-/// var money = pluralSecond('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars
+/// Text('money').pluralSub(1000000, format: NumberFormat.compact(locale: context.locale.toString())) // output: You have 1M dollars
+/// print('day'.pluralSub(21)); // output: 21 день
+/// var money = pluralSub('money', 10.23) // output: You have 10.23 dollars
+/// var money = pluralSub('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
+/// var money = pluralSub('money_named_args', 10.23, namedArgs: {'name': 'Jane'}, name: 'money')  // output: Jane has 10.23 dollars
 /// ```
 /// {@endtemplate}
-String pluralSecond(
+String pluralSub(
   String key,
   num value, {
   List<String>? args,
@@ -214,6 +212,6 @@ String pluralSecond(
   NumberFormat? format,
 }) {
   return context != null
-      ? Localization.of(context)!.pluralSecond(key, value, args: args, namedArgs: namedArgs, name: name, format: format)
-      : Localization.instance.pluralSecond(key, value, args: args, namedArgs: namedArgs, name: name, format: format);
+      ? Localization.of(context)!.pluralSub(key, value, args: args, namedArgs: namedArgs, name: name, format: format)
+      : Localization.instance.pluralSub(key, value, args: args, namedArgs: namedArgs, name: name, format: format);
 }

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -35,9 +35,9 @@ extension TextTranslateExtension on Text {
       semanticsLabel: semanticsLabel,
       textWidthBasis: textWidthBasis);
 
-  /// {@macro tr}
-  Text trSecond({List<String>? args, BuildContext? context, Map<String, String>? namedArgs, String? gender}) => Text(
-      ez.trSecond(
+  /// {@macro trSub}
+  Text trSub({List<String>? args, BuildContext? context, Map<String, String>? namedArgs, String? gender}) => Text(
+      ez.trSub(
         data ?? '',
         context: context,
         args: args,
@@ -89,8 +89,8 @@ extension TextTranslateExtension on Text {
           semanticsLabel: semanticsLabel,
           textWidthBasis: textWidthBasis);
 
-  /// {@macro plural}
-  Text pluralSecond(
+  /// {@macro pluralSub}
+  Text pluralSub(
     num value, {
     BuildContext? context,
     List<String>? args,
@@ -99,7 +99,7 @@ extension TextTranslateExtension on Text {
     NumberFormat? format,
   }) =>
       Text(
-          ez.pluralSecond(
+          ez.pluralSub(
             data ?? '',
             value,
             context: context,
@@ -138,18 +138,18 @@ extension StringTranslateExtension on String {
   }) =>
       ez.tr(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
 
-  /// {@macro tr}
-  String trSecond({
+  /// {@macro trSub}
+  String trSub({
     List<String>? args,
     Map<String, String>? namedArgs,
     String? gender,
     BuildContext? context,
   }) =>
-      ez.trSecond(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
+      ez.trSub(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
 
   bool trExists() => ez.trExists(this);
 
-  bool trSecondExists() => ez.trSecondExists(this);
+  bool trSubExists() => ez.trSubExists(this);
 
   /// {@macro plural}
   String plural(
@@ -170,8 +170,8 @@ extension StringTranslateExtension on String {
         format: format,
       );
 
-  /// {@macro pluralSecond}
-  String pluralSecond(
+  /// {@macro pluralSub}
+  String pluralSub(
     num value, {
     List<String>? args,
     BuildContext? context,
@@ -179,7 +179,7 @@ extension StringTranslateExtension on String {
     String? name,
     NumberFormat? format,
   }) =>
-      ez.pluralSecond(
+      ez.pluralSub(
         this,
         value,
         context: context,
@@ -207,12 +207,12 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
   /// Get current locale
   Locale get locale => EasyLocalization.of(this)!.locale;
 
-  Locale get secondLocale => EasyLocalization.of(this)!.secondLocale;
+  Locale get subLocale => EasyLocalization.of(this)!.subLocale;
 
   /// Change app locale
   Future<void> setLocale(Locale val) async => EasyLocalization.of(this)!.setLocale(val);
 
-  Future<void> setSecondLocale(Locale val) async => EasyLocalization.of(this)!.setSecondLocale(val);
+  Future<void> setSubLocale(Locale val) async => EasyLocalization.of(this)!.setSubLocale(val);
 
   /// Old Change app locale
   @Deprecated('This is the func used in the old version of EasyLocalization. The modern func is `setLocale(val)` . '
@@ -295,7 +295,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     );
   }
 
-  String trSecond(
+  String trSub(
     String key, {
     List<String>? args,
     Map<String, String>? namedArgs,
@@ -307,7 +307,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
       throw const LocalizationNotFoundException();
     }
 
-    return localization.trSecond(
+    return localization.trSub(
       key,
       args: args,
       namedArgs: namedArgs,
@@ -339,7 +339,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     );
   }
 
-  String pluralSecond(
+  String pluralSub(
     String key,
     num number, {
     List<String>? args,
@@ -353,7 +353,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
       throw const LocalizationNotFoundException();
     }
 
-    return localization.pluralSecond(
+    return localization.pluralSub(
       key,
       number,
       args: args,

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -35,6 +35,28 @@ extension TextTranslateExtension on Text {
       semanticsLabel: semanticsLabel,
       textWidthBasis: textWidthBasis);
 
+  /// {@macro tr}
+  Text trSecond({List<String>? args, BuildContext? context, Map<String, String>? namedArgs, String? gender}) => Text(
+      ez.trSecond(
+        data ?? '',
+        context: context,
+        args: args,
+        namedArgs: namedArgs,
+        gender: gender,
+      ),
+      key: key,
+      style: style,
+      strutStyle: strutStyle,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      locale: locale,
+      softWrap: softWrap,
+      overflow: overflow,
+      textScaleFactor: textScaleFactor,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      textWidthBasis: textWidthBasis);
+
   /// {@macro plural}
   Text plural(
     num value, {
@@ -46,6 +68,38 @@ extension TextTranslateExtension on Text {
   }) =>
       Text(
           ez.plural(
+            data ?? '',
+            value,
+            context: context,
+            args: args,
+            namedArgs: namedArgs,
+            name: name,
+            format: format,
+          ),
+          key: key,
+          style: style,
+          strutStyle: strutStyle,
+          textAlign: textAlign,
+          textDirection: textDirection,
+          locale: locale,
+          softWrap: softWrap,
+          overflow: overflow,
+          textScaleFactor: textScaleFactor,
+          maxLines: maxLines,
+          semanticsLabel: semanticsLabel,
+          textWidthBasis: textWidthBasis);
+
+  /// {@macro plural}
+  Text pluralSecond(
+    num value, {
+    BuildContext? context,
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? name,
+    NumberFormat? format,
+  }) =>
+      Text(
+          ez.pluralSecond(
             data ?? '',
             value,
             context: context,
@@ -84,7 +138,18 @@ extension StringTranslateExtension on String {
   }) =>
       ez.tr(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
 
+  /// {@macro tr}
+  String trSecond({
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? gender,
+    BuildContext? context,
+  }) =>
+      ez.trSecond(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
+
   bool trExists() => ez.trExists(this);
+
+  bool trSecondExists() => ez.trSecondExists(this);
 
   /// {@macro plural}
   String plural(
@@ -96,6 +161,25 @@ extension StringTranslateExtension on String {
     NumberFormat? format,
   }) =>
       ez.plural(
+        this,
+        value,
+        context: context,
+        args: args,
+        namedArgs: namedArgs,
+        name: name,
+        format: format,
+      );
+
+  /// {@macro pluralSecond}
+  String pluralSecond(
+    num value, {
+    List<String>? args,
+    BuildContext? context,
+    Map<String, String>? namedArgs,
+    String? name,
+    NumberFormat? format,
+  }) =>
+      ez.pluralSecond(
         this,
         value,
         context: context,

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -14,31 +14,26 @@ import 'public.dart' as ez;
 /// ```
 extension TextTranslateExtension on Text {
   /// {@macro tr}
-  Text tr(
-          {List<String>? args,
-          BuildContext? context,
-          Map<String, String>? namedArgs,
-          String? gender}) =>
-      Text(
-          ez.tr(
-            data ?? '',
-            context: context,
-            args: args,
-            namedArgs: namedArgs,
-            gender: gender,
-          ),
-          key: key,
-          style: style,
-          strutStyle: strutStyle,
-          textAlign: textAlign,
-          textDirection: textDirection,
-          locale: locale,
-          softWrap: softWrap,
-          overflow: overflow,
-          textScaleFactor: textScaleFactor,
-          maxLines: maxLines,
-          semanticsLabel: semanticsLabel,
-          textWidthBasis: textWidthBasis);
+  Text tr({List<String>? args, BuildContext? context, Map<String, String>? namedArgs, String? gender}) => Text(
+      ez.tr(
+        data ?? '',
+        context: context,
+        args: args,
+        namedArgs: namedArgs,
+        gender: gender,
+      ),
+      key: key,
+      style: style,
+      strutStyle: strutStyle,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      locale: locale,
+      softWrap: softWrap,
+      overflow: overflow,
+      textScaleFactor: textScaleFactor,
+      maxLines: maxLines,
+      semanticsLabel: semanticsLabel,
+      textWidthBasis: textWidthBasis);
 
   /// {@macro plural}
   Text plural(
@@ -87,8 +82,7 @@ extension StringTranslateExtension on String {
     String? gender,
     BuildContext? context,
   }) =>
-      ez.tr(this,
-          context: context, args: args, namedArgs: namedArgs, gender: gender);
+      ez.tr(this, context: context, args: args, namedArgs: namedArgs, gender: gender);
 
   bool trExists() => ez.trExists(this);
 
@@ -129,19 +123,20 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
   /// Get current locale
   Locale get locale => EasyLocalization.of(this)!.locale;
 
+  Locale get secondLocale => EasyLocalization.of(this)!.secondLocale;
+
   /// Change app locale
-  Future<void> setLocale(Locale val) async =>
-      EasyLocalization.of(this)!.setLocale(val);
+  Future<void> setLocale(Locale val) async => EasyLocalization.of(this)!.setLocale(val);
+
+  Future<void> setSecondLocale(Locale val) async => EasyLocalization.of(this)!.setSecondLocale(val);
 
   /// Old Change app locale
-  @Deprecated(
-      'This is the func used in the old version of EasyLocalization. The modern func is `setLocale(val)` . '
+  @Deprecated('This is the func used in the old version of EasyLocalization. The modern func is `setLocale(val)` . '
       'This feature was deprecated after v3.0.0')
   set locale(Locale val) => EasyLocalization.of(this)!.setLocale(val);
 
   /// Get List of supported locales.
-  List<Locale> get supportedLocales =>
-      EasyLocalization.of(this)!.supportedLocales;
+  List<Locale> get supportedLocales => EasyLocalization.of(this)!.supportedLocales;
 
   /// Get fallback locale
   Locale? get fallbackLocale => EasyLocalization.of(this)!.fallbackLocale;
@@ -156,12 +151,10 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
   ///     GlobalCupertinoLocalizations.delegate
   ///   ],
   /// ```
-  List<LocalizationsDelegate> get localizationDelegates =>
-      EasyLocalization.of(this)!.delegates;
+  List<LocalizationsDelegate> get localizationDelegates => EasyLocalization.of(this)!.delegates;
 
   /// Clears a saved locale from device storage
-  Future<void> deleteSaveLocale() =>
-      EasyLocalization.of(this)!.deleteSaveLocale();
+  Future<void> deleteSaveLocale() => EasyLocalization.of(this)!.deleteSaveLocale();
 
   /// Getting device locale from platform
   Locale get deviceLocale => EasyLocalization.of(this)!.deviceLocale;
@@ -218,6 +211,26 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     );
   }
 
+  String trSecond(
+    String key, {
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? gender,
+  }) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw const LocalizationNotFoundException();
+    }
+
+    return localization.trSecond(
+      key,
+      args: args,
+      namedArgs: namedArgs,
+      gender: gender,
+    );
+  }
+
   String plural(
     String key,
     num number, {
@@ -233,6 +246,30 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     }
 
     return localization.plural(
+      key,
+      number,
+      args: args,
+      namedArgs: namedArgs,
+      name: name,
+      format: format,
+    );
+  }
+
+  String pluralSecond(
+    String key,
+    num number, {
+    List<String>? args,
+    Map<String, String>? namedArgs,
+    String? name,
+    NumberFormat? format,
+  }) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw const LocalizationNotFoundException();
+    }
+
+    return localization.pluralSecond(
       key,
       number,
       args: args,

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 
 class FutureErrorWidget extends StatelessWidget {
   final String msg;
-  const FutureErrorWidget({Key? key, this.msg = 'Loading ...'})
-      : super(key: key);
+  const FutureErrorWidget({Key? key, this.msg = 'Loading ...'}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -20,16 +19,14 @@ class FutureErrorWidget extends StatelessWidget {
           'Easy Localization:',
           textAlign: TextAlign.center,
           textDirection: TextDirection.ltr,
-          style: TextStyle(
-              fontWeight: FontWeight.w700, color: Colors.red, fontSize: 25.0),
+          style: TextStyle(fontWeight: FontWeight.w700, color: Colors.red, fontSize: 25.0),
         ),
         const SizedBox(height: 10),
         Text(
           '"$msg"',
           textAlign: TextAlign.center,
           textDirection: TextDirection.ltr,
-          style: const TextStyle(
-              fontWeight: FontWeight.w500, color: Colors.red, fontSize: 14.0),
+          style: const TextStyle(fontWeight: FontWeight.w500, color: Colors.red, fontSize: 14.0),
         ),
         const SizedBox(height: 30),
         // Center(

--- a/test/easy_localization_context_test.dart
+++ b/test/easy_localization_context_test.dart
@@ -87,9 +87,7 @@ void main() async {
             saveLocale: false,
             useOnlyLangCode: true,
             // fallbackLocale:Locale('en') ,
-            supportedLocales: const [
-              Locale('ar')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('ar')], // Locale('en', 'US'), Locale('ar','DZ')
             child: const MyApp(),
           ));
           // await tester.idle();
@@ -117,10 +115,7 @@ void main() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
               // fallbackLocale:Locale('en') ,
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             // await tester.idle();
@@ -140,10 +135,7 @@ void main() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
               // fallbackLocale:Locale('en') ,
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             // await tester.idle();
@@ -161,10 +153,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             // await tester.idle();
@@ -182,10 +171,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: const Locale('ar', 'DZ'),
               child: const MyApp(),
             ));
@@ -208,10 +194,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             await tester.idle();
@@ -229,10 +212,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: const Locale('ar', 'DZ'),
               child: const MyApp(),
             ));

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -8,58 +8,49 @@ import 'package:flutter_test/flutter_test.dart';
 import 'utils/test_asset_loaders.dart';
 
 void main() {
-    group('language-specific-plurals', () {
-      var r = EasyLocalizationController(
-          forceLocale: const Locale('fb'),
-          supportedLocales: [const Locale('en'), const Locale('ru'), const Locale('fb')],
-          fallbackLocale: const Locale('fb'),
-          path: 'path',
-          useOnlyLangCode: true,
-          useFallbackTranslations: true,
-          onLoadError: (FlutterError e) {
-            log(e.toString());
-          },
-          saveLocale: false,
-          assetLoader: const JsonAssetLoader());
+  group('language-specific-plurals', () {
+    var r = EasyLocalizationController(
+        forceLocale: const Locale('fb'),
+        forceSecondLocale: const Locale('ru'),
+        supportedLocales: [const Locale('en'), const Locale('ru'), const Locale('fb')],
+        fallbackLocale: const Locale('fb'),
+        path: 'path',
+        useOnlyLangCode: true,
+        useFallbackTranslations: true,
+        onLoadError: (FlutterError e) {
+          log(e.toString());
+        },
+        saveLocale: false,
+        saveSecondLocale: true,
+        assetLoader: const JsonAssetLoader());
 
-      setUpAll(() async {
-        await r.loadTranslations();
-        
-      });
-
-      test('english one', () async {
-        Localization.load(const Locale('en'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 1), 'one hat');
-      }); 
-      test('english other', () async {
-        Localization.load(const Locale('en'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 2), 'other hats');
-        expect(Localization.instance.plural('hat', 0), 'other hats');
-        expect(Localization.instance.plural('hat', 3), 'other hats');
-      }); 
-      test('russian one', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 1), 'one hat');
-      }); 
-      test('russian few', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 2), 'few hats');
-        expect(Localization.instance.plural('hat', 3), 'few hats');
-      });
-      test('russian many', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 0), 'many hats');
-        expect(Localization.instance.plural('hat', 5), 'many hats');
-      });
+    setUpAll(() async {
+      await r.loadTranslations();
     });
+
+    test('english one', () async {
+      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 1), 'one hat');
+    });
+    test('english other', () async {
+      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 2), 'other hats');
+      expect(Localization.instance.plural('hat', 0), 'other hats');
+      expect(Localization.instance.plural('hat', 3), 'other hats');
+    });
+    test('russian one', () async {
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 1), 'one hat');
+    });
+    test('russian few', () async {
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 2), 'few hats');
+      expect(Localization.instance.plural('hat', 3), 'few hats');
+    });
+    test('russian many', () async {
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 0), 'many hats');
+      expect(Localization.instance.plural('hat', 5), 'many hats');
+    });
+  });
 }

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -26,6 +26,7 @@ void main() {
 
     setUpAll(() async {
       await r.loadTranslations();
+      await r.loadSubTranslations();
     });
 
     test('english one', () async {

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('language-specific-plurals', () {
     var r = EasyLocalizationController(
         forceLocale: const Locale('fb'),
-        forceSecondLocale: const Locale('ru'),
+        forceSubLocale: const Locale('ru'),
         supportedLocales: [const Locale('en'), const Locale('ru'), const Locale('fb')],
         fallbackLocale: const Locale('fb'),
         path: 'path',
@@ -21,7 +21,7 @@ void main() {
           log(e.toString());
         },
         saveLocale: false,
-        saveSecondLocale: true,
+        saveSubLocale: true,
         assetLoader: const JsonAssetLoader());
 
     setUpAll(() async {
@@ -29,26 +29,26 @@ void main() {
     });
 
     test('english one', () async {
-      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       expect(Localization.instance.plural('hat', 1), 'one hat');
     });
     test('english other', () async {
-      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      Localization.load(const Locale('en'), const Locale('ru'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       expect(Localization.instance.plural('hat', 2), 'other hats');
       expect(Localization.instance.plural('hat', 0), 'other hats');
       expect(Localization.instance.plural('hat', 3), 'other hats');
     });
     test('russian one', () async {
-      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       expect(Localization.instance.plural('hat', 1), 'one hat');
     });
     test('russian few', () async {
-      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       expect(Localization.instance.plural('hat', 2), 'few hats');
       expect(Localization.instance.plural('hat', 3), 'few hats');
     });
     test('russian many', () async {
-      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+      Localization.load(const Locale('ru'), const Locale('en'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       expect(Localization.instance.plural('hat', 0), 'many hats');
       expect(Localization.instance.plural('hat', 5), 'many hats');
     });

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -15,20 +15,20 @@ void main() {
   group('localization', () {
     var r1 = EasyLocalizationController(
         forceLocale: const Locale('en'),
-        forceSecondLocale: const Locale('en'),
+        forceSubLocale: const Locale('en'),
         path: 'path/en.json',
         supportedLocales: const [Locale('en')],
         useOnlyLangCode: true,
         useFallbackTranslations: false,
         saveLocale: false,
-        saveSecondLocale: false,
+        saveSubLocale: false,
         onLoadError: (FlutterError e) {
           log(e.toString());
         },
         assetLoader: const JsonAssetLoader());
     var r2 = EasyLocalizationController(
         forceLocale: const Locale('en', 'us'),
-        forceSecondLocale: const Locale('en', 'us'),
+        forceSubLocale: const Locale('en', 'us'),
         supportedLocales: const [Locale('en', 'us')],
         path: 'path/en-us.json',
         useOnlyLangCode: false,
@@ -37,7 +37,7 @@ void main() {
           log(e.toString());
         },
         saveLocale: false,
-        saveSecondLocale: false,
+        saveSubLocale: false,
         assetLoader: const JsonAssetLoader());
     setUpAll(() async {
       EasyLocalization.logger.enableLevels = <LevelMessages>[
@@ -47,7 +47,7 @@ void main() {
 
       await r1.loadTranslations();
       await r2.loadTranslations();
-      Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, secondTranslations: r1.secondTranslations);
+      Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, subTranslations: r1.subTranslations);
     });
     test('is a localization object', () {
       expect(Localization.instance, isInstanceOf<Localization>());
@@ -61,17 +61,17 @@ void main() {
     });
 
     test('load() succeeds', () async {
-      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, secondTranslations: r1.secondTranslations), true);
+      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, subTranslations: r1.subTranslations), true);
     });
 
     test('load() with fallback succeeds', () async {
-      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, secondTranslations: r1.secondTranslations, fallbackTranslations: r2.translations), true);
+      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, subTranslations: r1.subTranslations, fallbackTranslations: r2.translations), true);
     });
 
     test('merge fallbackLocale with locale without country code succeeds', () async {
       await EasyLocalizationController(
         forceLocale: const Locale('es', 'AR'),
-        forceSecondLocale: const Locale('es', 'AR'),
+        forceSubLocale: const Locale('es', 'AR'),
         supportedLocales: const [Locale('en'), Locale('es'), Locale('es', 'AR')],
         path: 'path/en-us.json',
         useOnlyLangCode: false,
@@ -81,7 +81,7 @@ void main() {
           throw e;
         },
         saveLocale: false,
-        saveSecondLocale: false,
+        saveSubLocale: false,
         assetLoader: const ImmutableJsonAssetLoader(),
       ).loadTranslations();
     });
@@ -95,7 +95,7 @@ void main() {
 
     test('load() Failed assertion', () async {
       try {
-        Localization.load(const Locale('en'), const Locale('ru'), translations: null, secondTranslations: null);
+        Localization.load(const Locale('en'), const Locale('ru'), translations: null, subTranslations: null);
       } on AssertionError catch (e) {
         // throw  AssertionError('Expected ArgumentError');
         expect(e, isAssertionError);
@@ -103,7 +103,7 @@ void main() {
     });
 
     test('load() correctly sets locale path', () async {
-      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, secondTranslations: r1.secondTranslations), true);
+      expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, subTranslations: r1.subTranslations), true);
       expect(Localization.instance.tr('path'), 'path/en.json');
     });
 
@@ -111,7 +111,7 @@ void main() {
       expect(Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations), true);
       expect(Localization.instance.tr('path'), 'path/en.json');
 
-      expect(Localization.load(const Locale('en', 'us'), const Locale('en', 'us'), translations: r2.translations, secondTranslations: r2.secondTranslations), true);
+      expect(Localization.load(const Locale('en', 'us'), const Locale('en', 'us'), translations: r2.translations, subTranslations: r2.subTranslations), true);
       expect(Localization.instance.tr('path'), 'path/en-us.json');
     });
 
@@ -130,7 +130,7 @@ void main() {
           log(e.toString());
         },
         saveLocale: true,
-        saveSecondLocale: true,
+        saveSubLocale: true,
         assetLoader: const JsonAssetLoader(),
       );
       expect(controller.locale, const Locale('en'));
@@ -154,7 +154,7 @@ void main() {
           log(e.toString());
         },
         saveLocale: true,
-        saveSecondLocale: true,
+        saveSubLocale: true,
         assetLoader: const JsonAssetLoader(),
       );
       expect(controller.locale, const Locale('fb'));
@@ -208,7 +208,7 @@ void main() {
     group('tr', () {
       var r = EasyLocalizationController(
           forceLocale: const Locale('en'),
-          forceSecondLocale: const Locale('en'),
+          forceSubLocale: const Locale('en'),
           supportedLocales: const [Locale('en'), Locale('fb')],
           fallbackLocale: const Locale('fb'),
           path: 'path',
@@ -218,12 +218,12 @@ void main() {
             log(e.toString());
           },
           saveLocale: false,
-          saveSecondLocale: false,
+          saveSubLocale: false,
           assetLoader: const JsonAssetLoader());
 
       setUpAll(() async {
         await r.loadTranslations();
-        Localization.load(const Locale('en'), const Locale('en'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+        Localization.load(const Locale('en'), const Locale('en'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       });
       test('finds and returns resource', () {
         expect(Localization.instance.tr('test'), 'test');
@@ -369,7 +369,7 @@ void main() {
     group('plural', () {
       var r = EasyLocalizationController(
           forceLocale: const Locale('fb'),
-          forceSecondLocale: const Locale('fb'),
+          forceSubLocale: const Locale('fb'),
           supportedLocales: [const Locale('fb')],
           fallbackLocale: const Locale('fb'),
           path: 'path',
@@ -379,12 +379,12 @@ void main() {
             log(e.toString());
           },
           saveLocale: false,
-          saveSecondLocale: false,
+          saveSubLocale: false,
           assetLoader: const JsonAssetLoader());
 
       setUpAll(() async {
         await r.loadTranslations();
-        Localization.load(const Locale('fb'), const Locale('fb'), translations: r.translations, secondTranslations: r.secondTranslations, fallbackTranslations: r.fallbackTranslations);
+        Localization.load(const Locale('fb'), const Locale('fb'), translations: r.translations, subTranslations: r.subTranslations, fallbackTranslations: r.fallbackTranslations);
       });
 
       test('zero', () {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -46,7 +46,9 @@ void main() {
       ];
 
       await r1.loadTranslations();
+      await r1.loadSubTranslations();
       await r2.loadTranslations();
+      await r2.loadSubTranslations();
       Localization.load(const Locale('en'), const Locale('en'), translations: r1.translations, subTranslations: r1.subTranslations);
     });
     test('is a localization object', () {
@@ -69,7 +71,7 @@ void main() {
     });
 
     test('merge fallbackLocale with locale without country code succeeds', () async {
-      await EasyLocalizationController(
+      EasyLocalizationController(
         forceLocale: const Locale('es', 'AR'),
         forceSubLocale: const Locale('es', 'AR'),
         supportedLocales: const [Locale('en'), Locale('es'), Locale('es', 'AR')],
@@ -83,7 +85,9 @@ void main() {
         saveLocale: false,
         saveSubLocale: false,
         assetLoader: const ImmutableJsonAssetLoader(),
-      ).loadTranslations();
+      )
+        ..loadTranslations()
+        ..loadSubTranslations();
     });
 
     test('localeFromString() succeeds', () async {

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -50,6 +50,23 @@ class MyWidget extends StatelessWidget {
   }
 }
 
+class MySubWidget extends StatelessWidget {
+  const MySubWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(context) {
+    _context = context;
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          const Text('test').trSub(),
+          const Text('day').pluralSub(1),
+        ],
+      ),
+    );
+  }
+}
+
 class MyLocalizedWidget extends StatelessWidget {
   const MyLocalizedWidget({Key? key}) : super(key: key);
 
@@ -219,7 +236,7 @@ void main() async {
   );
 
   testWidgets(
-    '[EasyLocalization] change second locale test',
+    '[EasyLocalization] change sub locale test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
@@ -232,12 +249,12 @@ void main() async {
         await tester.pump();
 
         expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
-        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+        expect(EasyLocalization.of(_context)!.subLocale, const Locale('en', 'US'));
 
         var l = const Locale('en', 'US');
-        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await EasyLocalization.of(_context)!.setSubLocale(l);
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+        expect(EasyLocalization.of(_context)!.subLocale, const Locale('en', 'US'));
 
         final trFinder = find.text('test');
         expect(trFinder, findsOneWidget);
@@ -249,10 +266,10 @@ void main() async {
 
         l = const Locale('ar', 'DZ');
         expect(() async {
-          await EasyLocalization.of(_context)!.setSecondLocale(l);
+          await EasyLocalization.of(_context)!.setSubLocale(l);
         }, throwsAssertionError);
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+        expect(EasyLocalization.of(_context)!.subLocale, const Locale('en', 'US'));
       });
     },
   );
@@ -325,7 +342,7 @@ void main() async {
 
         expect(Localization.of(_context), isInstanceOf<Localization>());
         expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+        expect(EasyLocalization.of(_context)!.subLocale, const Locale('en', 'US'));
 
         var trFinder = find.text('test');
         expect(trFinder, findsOneWidget);
@@ -335,30 +352,30 @@ void main() async {
         expect(tr('test'), 'test');
 
         var l = const Locale('en', 'US');
-        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await EasyLocalization.of(_context)!.setSubLocale(l);
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, l);
+        expect(EasyLocalization.of(_context)!.subLocale, l);
 
         l = const Locale('ar', 'DZ');
-        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await EasyLocalization.of(_context)!.setSubLocale(l);
         // await tester.idle();
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, l);
+        expect(EasyLocalization.of(_context)!.subLocale, l);
 
         l = const Locale('en', 'US');
-        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await EasyLocalization.of(_context)!.setSubLocale(l);
         // await tester.idle();
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, l);
+        expect(EasyLocalization.of(_context)!.subLocale, l);
 
         l = const Locale('en', 'UK');
-        expect(() async => {await EasyLocalization.of(_context)!.setSecondLocale(l)}, throwsAssertionError);
+        expect(() async => {await EasyLocalization.of(_context)!.setSubLocale(l)}, throwsAssertionError);
 
         l = const Locale('ar', 'DZ');
-        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await EasyLocalization.of(_context)!.setSubLocale(l);
         // await tester.idle();
         await tester.pump();
-        expect(EasyLocalization.of(_context)!.secondLocale, l);
+        expect(EasyLocalization.of(_context)!.subLocale, l);
       });
     },
   );
@@ -394,6 +411,47 @@ void main() async {
         expect(plural('day', 1), '1 يوم');
         expect(plural('day', 2), '2 أيام');
         expect(plural('day', 3), '3 أيام');
+
+        // var l = Locale('en', 'US');
+        // EasyLocalization.of(_context).locale = l;
+        // expect(EasyLocalization.of(_context).locale, l);
+      });
+    },
+  );
+
+  testWidgets(
+    '[EasyLocalization] sub locale ar_DZ test',
+    (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(EasyLocalization(
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
+          child: const MyApp(
+            child: MySubWidget(),
+          ),
+        ));
+
+        // await tester.idle();
+        // The async delegator load will require build on the next frame. Thus, pump
+        await tester.pump();
+
+        await EasyLocalization.of(_context)!.setSubLocale(const Locale('ar', 'DZ'));
+
+        await tester.pump();
+
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.subLocale, const Locale('ar', 'DZ'));
+
+        var trFinder = find.text('اختبار');
+        expect(trFinder, findsOneWidget);
+        var pluralFinder = find.text('1 يوم');
+        expect(pluralFinder, findsOneWidget);
+
+        expect(Localization.of(_context), isInstanceOf<Localization>());
+        expect(trSub('test'), 'اختبار');
+        expect(pluralSub('day', 1), '1 يوم');
+        expect(pluralSub('day', 2), '2 أيام');
+        expect(pluralSub('day', 3), '3 أيام');
 
         // var l = Locale('en', 'US');
         // EasyLocalization.of(_context).locale = l;
@@ -790,7 +848,7 @@ void main() async {
       path: '../../i18n',
       supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
       startLocale: const Locale('en', 'US'),
-      startSecondLocale: const Locale('en', 'US'),
+      startSubLocale: const Locale('en', 'US'),
       child: const MyApp(
         child: MyLocalizedWidget(),
       ),

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -95,8 +95,7 @@ void main() async {
         expect(Localization.of(_context), isInstanceOf<Localization>());
         expect(Localization.instance, isInstanceOf<Localization>());
         expect(Localization.instance, Localization.of(_context));
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test');
@@ -125,8 +124,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test');
@@ -151,8 +149,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test');
@@ -176,15 +173,14 @@ void main() async {
         // await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
-        final trFinder =
-            find.byWidgetPredicate((widget) => widget is ErrorWidget);
+        final trFinder = find.byWidgetPredicate((widget) => widget is ErrorWidget);
         expect(trFinder, findsOneWidget);
         await tester.pump();
       });
     },
   );
   testWidgets(
-    '[EasyLocalization] change loacle test',
+    '[EasyLocalization] change locale test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
@@ -196,8 +192,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         var l = const Locale('en', 'US');
@@ -224,7 +219,46 @@ void main() async {
   );
 
   testWidgets(
-    '[EasyLocalization] change loacle test',
+    '[EasyLocalization] change second locale test',
+    (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(EasyLocalization(
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'US')],
+          child: const MyApp(),
+        ));
+        // await tester.idle();
+        // The async delegator load will require build on the next frame. Thus, pump
+        await tester.pump();
+
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+
+        var l = const Locale('en', 'US');
+        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+
+        final trFinder = find.text('test');
+        expect(trFinder, findsOneWidget);
+        final pluralFinder = find.text('1 day');
+        expect(pluralFinder, findsOneWidget);
+
+        expect(tr('test'), 'test');
+        expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+
+        l = const Locale('ar', 'DZ');
+        expect(() async {
+          await EasyLocalization.of(_context)!.setSecondLocale(l);
+        }, throwsAssertionError);
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+      });
+    },
+  );
+
+  testWidgets(
+    '[EasyLocalization] change locale test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
@@ -237,8 +271,7 @@ void main() async {
         await tester.pump();
 
         expect(Localization.of(_context), isInstanceOf<Localization>());
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         var trFinder = find.text('test');
@@ -266,8 +299,7 @@ void main() async {
         expect(EasyLocalization.of(_context)!.locale, l);
 
         l = const Locale('en', 'UK');
-        expect(() async => {await EasyLocalization.of(_context)!.setLocale(l)},
-            throwsAssertionError);
+        expect(() async => {await EasyLocalization.of(_context)!.setLocale(l)}, throwsAssertionError);
 
         l = const Locale('ar', 'DZ');
         await EasyLocalization.of(_context)!.setLocale(l);
@@ -279,7 +311,60 @@ void main() async {
   );
 
   testWidgets(
-    '[EasyLocalization] loacle ar_DZ test',
+    '[EasyLocalization] change locale test',
+    (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(EasyLocalization(
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
+          child: const MyApp(),
+        ));
+        // await tester.idle();
+        // The async delegator load will require build on the next frame. Thus, pump
+        await tester.pump();
+
+        expect(Localization.of(_context), isInstanceOf<Localization>());
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.secondLocale, const Locale('en', 'US'));
+
+        var trFinder = find.text('test');
+        expect(trFinder, findsOneWidget);
+        var pluralFinder = find.text('1 day');
+        expect(pluralFinder, findsOneWidget);
+
+        expect(tr('test'), 'test');
+
+        var l = const Locale('en', 'US');
+        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, l);
+
+        l = const Locale('ar', 'DZ');
+        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        // await tester.idle();
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, l);
+
+        l = const Locale('en', 'US');
+        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        // await tester.idle();
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, l);
+
+        l = const Locale('en', 'UK');
+        expect(() async => {await EasyLocalization.of(_context)!.setSecondLocale(l)}, throwsAssertionError);
+
+        l = const Locale('ar', 'DZ');
+        await EasyLocalization.of(_context)!.setSecondLocale(l);
+        // await tester.idle();
+        await tester.pump();
+        expect(EasyLocalization.of(_context)!.secondLocale, l);
+      });
+    },
+  );
+
+  testWidgets(
+    '[EasyLocalization] locale ar_DZ test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
@@ -292,13 +377,11 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        await EasyLocalization.of(_context)!
-            .setLocale(const Locale('ar', 'DZ'));
+        await EasyLocalization.of(_context)!.setLocale(const Locale('ar', 'DZ'));
 
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
 
         var trFinder = find.text('اختبار');
@@ -334,8 +417,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en'), const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
 
         var l = const Locale('en');
@@ -360,8 +442,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en'), const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
 
         var l = const Locale('en');
@@ -387,11 +468,9 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
-        expect(
-            EasyLocalization.of(_context)!.fallbackLocale, const Locale('ar'));
+        expect(EasyLocalization.of(_context)!.fallbackLocale, const Locale('ar'));
       });
     },
   );
@@ -412,8 +491,7 @@ void main() async {
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
         expect(EasyLocalization.of(_context)!.fallbackLocale, null);
       });
@@ -442,8 +520,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en'), const Locale('ar')]);
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
           expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
@@ -464,10 +541,8 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -488,10 +563,8 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -522,8 +595,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en'), const Locale('ar')]);
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
           expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
@@ -554,10 +626,8 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -578,13 +648,10 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-          await EasyLocalization.of(_context)!
-              .setLocale(const Locale('en', 'US'));
+          await EasyLocalization.of(_context)!.setLocale(const Locale('en', 'US'));
         });
       },
     );
@@ -610,8 +677,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           await EasyLocalization.of(_context)!.deleteSaveLocale();
         });
       },
@@ -631,8 +697,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -650,8 +715,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.deviceLocale.toString(),
-              Platform.localeName);
+          expect(EasyLocalization.of(_context)!.deviceLocale.toString(), Platform.localeName);
         });
       },
     );
@@ -662,10 +726,7 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
             path: '../../i18n',
-            supportedLocales: const [
-              Locale('en', 'US'),
-              Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: const Locale('ar', 'DZ'),
             child: const MyApp(),
           ));
@@ -673,13 +734,11 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           // reset to device locale
           await _context.resetLocale();
           await tester.pump();
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -697,8 +756,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
-          expect(EasyLocalization.of(_context)!.deviceLocale.toString(),
-              Platform.localeName);
+          expect(EasyLocalization.of(_context)!.deviceLocale.toString(), Platform.localeName);
         });
       },
     );
@@ -709,10 +767,7 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
             path: '../../i18n',
-            supportedLocales: const [
-              Locale('en', 'US'),
-              Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: const Locale('ar', 'DZ'),
             child: const MyApp(),
           ));
@@ -720,13 +775,11 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           // reset to device locale
           await _context.resetLocale();
           await tester.pumpAndSettle();
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -735,11 +788,9 @@ void main() async {
   group('Context extensions tests', () {
     final testWidget = EasyLocalization(
       path: '../../i18n',
-      supportedLocales: const [
-        Locale('en', 'US'),
-        Locale('ar', 'DZ')
-      ], // Locale('en', 'US'), Locale('ar','DZ')
+      supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
       startLocale: const Locale('en', 'US'),
+      startSecondLocale: const Locale('en', 'US'),
       child: const MyApp(
         child: MyLocalizedWidget(),
       ),
@@ -764,7 +815,7 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(testWidget);
 
-          await tester.idle();
+          await tester.pump();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
@@ -813,13 +864,11 @@ void main() async {
           await tester.pumpAndSettle();
 
           expect(
-            initialTranslationValue != _contextTranslationValue &&
-                _contextTranslationValue == expectedArTranslateTextWidgetValue,
+            initialTranslationValue != _contextTranslationValue && _contextTranslationValue == expectedArTranslateTextWidgetValue,
             true,
           );
           expect(
-            initialPluralValue != _contextPluralValue &&
-                _contextPluralValue == expectedArPluralTextWidgetValue,
+            initialPluralValue != _contextPluralValue && _contextPluralValue == expectedArPluralTextWidgetValue,
             true,
           );
         });

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -420,47 +420,6 @@ void main() async {
   );
 
   testWidgets(
-    '[EasyLocalization] sub locale ar_DZ test',
-    (WidgetTester tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(EasyLocalization(
-          path: '../../i18n',
-          supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
-          child: const MyApp(
-            child: MySubWidget(),
-          ),
-        ));
-
-        // await tester.idle();
-        // The async delegator load will require build on the next frame. Thus, pump
-        await tester.pump();
-
-        await EasyLocalization.of(_context)!.setSubLocale(const Locale('ar', 'DZ'));
-
-        await tester.pump();
-
-        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-        expect(EasyLocalization.of(_context)!.subLocale, const Locale('ar', 'DZ'));
-
-        var trFinder = find.text('اختبار');
-        expect(trFinder, findsOneWidget);
-        var pluralFinder = find.text('1 يوم');
-        expect(pluralFinder, findsOneWidget);
-
-        expect(Localization.of(_context), isInstanceOf<Localization>());
-        expect(trSub('test'), 'اختبار');
-        expect(pluralSub('day', 1), '1 يوم');
-        expect(pluralSub('day', 2), '2 أيام');
-        expect(pluralSub('day', 3), '3 أيام');
-
-        // var l = Locale('en', 'US');
-        // EasyLocalization.of(_context).locale = l;
-        // expect(EasyLocalization.of(_context).locale, l);
-      });
-    },
-  );
-
-  testWidgets(
     '[EasyLocalization] fallbackLocale with doesn\'t saveLocale test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {


### PR DESCRIPTION
This way you could provide multi language for people. Say for example a learning app like Duolingo, hereby you can then specify the main and sub language.

Or if you want to have a mix of two dialects you can do it this way.
