### PR TITLE
Recommend usage of context in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,19 @@ context.setLocale(Locale('en', 'US'));
 print(context.locale.toString());
 ```
 
-### 🔥 Translate `tr()`
+### 🔥 Translate `context.tr()`
 
 Main function for translate your language keys
 
 You can use extension methods of [String] or [Text] widget, you can also use `tr()` as a static function.
+
+```dart
+Text(context.tr('title'))
+```
+
+You can also use tr() without [Context] as a static function.
+
+This is not recommend in build methods, because the widget won't rebuild when the language changes.
 
 ```dart
 Text('title').tr() //Text widget
@@ -196,8 +204,6 @@ Text('title').tr() //Text widget
 print('title'.tr()); //String
 
 var title = tr('title') //Static function
-
-Text(context.tr('title')) //Extension on BuildContext
 ```
 
 #### Arguments:


### PR DESCRIPTION
People use `tr() `because it seems very convenient.

However, when changing the language, they are confused because the text does not update.

In my opinion, `context.tr()` should be the main usage pattern.

Static `tr()` only makes sense in scenarios where you don't have a BuildContext.

See #439 for examples.
