### PR TITLE
Fix #648: allow using "old" (e.g. pre-3.0.4) plural rules evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ output.json
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 
 ### VisualStudioCode ###
+.vscode/
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
@@ -203,6 +204,7 @@ obj/
 /out/
 
 # User-specific configurations
+.idea/
 .idea/caches/
 .idea/libraries/
 .idea/shelf/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ void main() async {
     // startLocale: Locale('de', 'DE'),
     // saveLocale: false,
     // useOnlyLangCode: true,
-    // ignorePluralRules: true,
+    // ignorePluralRules: false,
 
     // optional assetLoader default used is RootBundleAssetLoader which uses flutter's assetloader
     // install easy_localization_loader for enable custom loaders

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,7 @@ void main() async {
     // startLocale: Locale('de', 'DE'),
     // saveLocale: false,
     // useOnlyLangCode: true,
+    forcePluralCaseFallback: true,
 
     // optional assetLoader default used is RootBundleAssetLoader which uses flutter's assetloader
     // install easy_localization_loader for enable custom loaders

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ void main() async {
     // startLocale: Locale('de', 'DE'),
     // saveLocale: false,
     // useOnlyLangCode: true,
-    forcePluralCaseFallback: true,
+    // ignorePluralRules: true,
 
     // optional assetLoader default used is RootBundleAssetLoader which uses flutter's assetloader
     // install easy_localization_loader for enable custom loaders

--- a/example/resources/langs/en-US.json
+++ b/example/resources/langs/en-US.json
@@ -11,12 +11,10 @@
         }
     },
     "clicked": {
-        "zero": "You clicked {} times!",
-        "one": "You clicked {} time!",
-        "two": "You clicked {} times!",
-        "few": "You clicked {} times!",
-        "many": "You clicked {} times!",
-        "other": "You clicked {} times!"
+        "zero": "You didn't click yet!",
+        "few": "You clicked a few times ({})!",
+        "many": "You clicked many times ({})!",
+        "other": "You clicked {} time(s)!"
     },
     "amount": {
         "zero": "Your amount : {} ",

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -63,6 +63,21 @@ class EasyLocalization extends StatefulWidget {
   /// ```
   final bool useFallbackTranslationsForEmptyResources;
 
+  /// Force use of plural strings for all languages. This will still fallback
+  /// to "other" if the specific rule isn't defined.
+  /// @Default value false
+  /// Example:
+  /// ```
+  /// // Default behavior, will use "zero" rule for 0 only if the language
+  /// // is set to do so (e.g. for "lt" but not for "en").
+  /// forcePluralCaseFallback: false
+  /// // Force using "zero" rule for 0 even if the language doesn't use it
+  /// // by default (e.g. "en"). If "zero" localization for that string
+  /// // doesn't exist, "other" is still used as fallback.
+  /// forcePluralCaseFallback: true
+  /// ```
+  final bool forcePluralCaseFallback;
+
   /// Path to your folder with localization files.
   /// Example:
   /// ```dart
@@ -117,6 +132,7 @@ class EasyLocalization extends StatefulWidget {
     this.useOnlyLangCode = false,
     this.useFallbackTranslations = false,
     this.useFallbackTranslationsForEmptyResources = false,
+    this.forcePluralCaseFallback = false,
     this.assetLoader = const RootBundleAssetLoader(),
     this.extraAssetLoaders,
     this.saveLocale = true,
@@ -198,6 +214,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
         supportedLocales: widget.supportedLocales,
         useFallbackTranslationsForEmptyResources:
             widget.useFallbackTranslationsForEmptyResources,
+        forcePluralCaseFallback: widget.forcePluralCaseFallback,
       ),
     );
   }
@@ -243,6 +260,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   /// Get fallback locale
   Locale? get fallbackLocale => parent.fallbackLocale;
+
   // Locale get startLocale => parent.startLocale;
 
   /// Change app locale
@@ -278,12 +296,14 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   final List<Locale>? supportedLocales;
   final EasyLocalizationController? localizationController;
   final bool useFallbackTranslationsForEmptyResources;
+  final bool forcePluralCaseFallback;
 
   ///  * use only the lang code to generate i18n file path like en.json or ar.json
   // final bool useOnlyLangCode;
 
   _EasyLocalizationDelegate({
     required this.useFallbackTranslationsForEmptyResources,
+    this.forcePluralCaseFallback = false,
     this.localizationController,
     this.supportedLocales,
   }) {
@@ -306,6 +326,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       fallbackTranslations: localizationController!.fallbackTranslations,
       useFallbackTranslationsForEmptyResources:
           useFallbackTranslationsForEmptyResources,
+      forcePluralCaseFallback: forcePluralCaseFallback,
     );
     return Future.value(Localization.instance);
   }

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -63,20 +63,25 @@ class EasyLocalization extends StatefulWidget {
   /// ```
   final bool useFallbackTranslationsForEmptyResources;
 
-  /// Force use of plural strings for all languages. This will still fallback
-  /// to "other" if the specific rule isn't defined.
+  /// Ignore usage of plural strings for languages that do not use plural rules.
   /// @Default value false
   /// Example:
   /// ```
-  /// // Default behavior, will use "zero" rule for 0 only if the language
-  /// // is set to do so (e.g. for "lt" but not for "en").
-  /// forcePluralCaseFallback: false
-  /// // Force using "zero" rule for 0 even if the language doesn't use it
-  /// // by default (e.g. "en"). If "zero" localization for that string
+  /// // Default behavior, use "zero" rule for 0 even if the language doesn't
+  /// // use it by default (e.g. "en"). If "zero" localization for that string
   /// // doesn't exist, "other" is still used as fallback.
-  /// forcePluralCaseFallback: true
+  /// // "nTimes": "{count, plural, =0{never} =1{once} other{{count} times}}"
+  /// // Text(AppLocalizations.of(context)!.nTimes(_counter)),
+  /// // will print "never, once, 2 times" for ALL languages.
+  /// ignorePluralRules: false
+  /// // Use "zero" rule for 0 only if the language is set to do so (e.g. for
+  /// "lt" but not for "en").
+  /// // "nTimes": "{count, plural, =0{never} =1{once} other{{count} times}}"
+  /// // Text(AppLocalizations.of(context)!.nTimes(_counter)),
+  /// // will print "never, once, 2 times" ONLY for languages with plural rules.
+  /// ignorePluralRules: true
   /// ```
-  final bool forcePluralCaseFallback;
+  final bool ignorePluralRules;
 
   /// Path to your folder with localization files.
   /// Example:
@@ -132,7 +137,7 @@ class EasyLocalization extends StatefulWidget {
     this.useOnlyLangCode = false,
     this.useFallbackTranslations = false,
     this.useFallbackTranslationsForEmptyResources = false,
-    this.forcePluralCaseFallback = false,
+    this.ignorePluralRules = false,
     this.assetLoader = const RootBundleAssetLoader(),
     this.extraAssetLoaders,
     this.saveLocale = true,
@@ -214,7 +219,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
         supportedLocales: widget.supportedLocales,
         useFallbackTranslationsForEmptyResources:
             widget.useFallbackTranslationsForEmptyResources,
-        forcePluralCaseFallback: widget.forcePluralCaseFallback,
+        ignorePluralRules: widget.ignorePluralRules,
       ),
     );
   }
@@ -296,14 +301,14 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   final List<Locale>? supportedLocales;
   final EasyLocalizationController? localizationController;
   final bool useFallbackTranslationsForEmptyResources;
-  final bool forcePluralCaseFallback;
+  final bool ignorePluralRules;
 
   ///  * use only the lang code to generate i18n file path like en.json or ar.json
   // final bool useOnlyLangCode;
 
   _EasyLocalizationDelegate({
     required this.useFallbackTranslationsForEmptyResources,
-    this.forcePluralCaseFallback = false,
+    this.ignorePluralRules = false,
     this.localizationController,
     this.supportedLocales,
   }) {
@@ -326,7 +331,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       fallbackTranslations: localizationController!.fallbackTranslations,
       useFallbackTranslationsForEmptyResources:
           useFallbackTranslationsForEmptyResources,
-      forcePluralCaseFallback: forcePluralCaseFallback,
+      ignorePluralRules: ignorePluralRules,
     );
     return Future.value(Localization.instance);
   }

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -73,13 +73,13 @@ class EasyLocalization extends StatefulWidget {
   /// // "nTimes": "{count, plural, =0{never} =1{once} other{{count} times}}"
   /// // Text(AppLocalizations.of(context)!.nTimes(_counter)),
   /// // will print "never, once, 2 times" for ALL languages.
-  /// ignorePluralRules: false
+  /// ignorePluralRules: true
   /// // Use "zero" rule for 0 only if the language is set to do so (e.g. for
   /// "lt" but not for "en").
   /// // "nTimes": "{count, plural, =0{never} =1{once} other{{count} times}}"
   /// // Text(AppLocalizations.of(context)!.nTimes(_counter)),
   /// // will print "never, once, 2 times" ONLY for languages with plural rules.
-  /// ignorePluralRules: true
+  /// ignorePluralRules: false
   /// ```
   final bool ignorePluralRules;
 
@@ -137,7 +137,7 @@ class EasyLocalization extends StatefulWidget {
     this.useOnlyLangCode = false,
     this.useFallbackTranslations = false,
     this.useFallbackTranslationsForEmptyResources = false,
-    this.ignorePluralRules = false,
+    this.ignorePluralRules = true,
     this.assetLoader = const RootBundleAssetLoader(),
     this.extraAssetLoaders,
     this.saveLocale = true,
@@ -308,7 +308,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
 
   _EasyLocalizationDelegate({
     required this.useFallbackTranslationsForEmptyResources,
-    this.ignorePluralRules = false,
+    this.ignorePluralRules = true,
     this.localizationController,
     this.supportedLocales,
   }) {

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -20,11 +20,14 @@ class Localization {
   };
 
   bool _useFallbackTranslationsForEmptyResources = false;
+  bool _forcePluralCaseFallback = false;
 
   Localization();
 
   static Localization? _instance;
+
   static Localization get instance => _instance ?? (_instance = Localization());
+
   static Localization? of(BuildContext context) =>
       Localizations.of<Localization>(context, Localization);
 
@@ -33,12 +36,14 @@ class Localization {
     Translations? translations,
     Translations? fallbackTranslations,
     bool useFallbackTranslationsForEmptyResources = false,
+    bool forcePluralCaseFallback = false,
   }) {
     instance._locale = locale;
     instance._translations = translations;
     instance._fallbackTranslations = fallbackTranslations;
     instance._useFallbackTranslationsForEmptyResources =
         useFallbackTranslationsForEmptyResources;
+    instance._forcePluralCaseFallback = forcePluralCaseFallback;
     return translations == null ? false : true;
   }
 
@@ -114,6 +119,9 @@ class Localization {
   }
 
   static PluralRule? _pluralRule(String? locale, num howMany) {
+    if (instance._forcePluralCaseFallback) {
+      return () => _pluralCaseFallback(howMany);
+    }
     startRuleEvaluation(howMany);
     return pluralRules[locale];
   }
@@ -139,11 +147,11 @@ class Localization {
     String? name,
     NumberFormat? format,
   }) {
-
     late String res;
 
     final pluralRule = _pluralRule(_locale.languageCode, value);
-    final pluralCase = pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
+    final pluralCase =
+        pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
 
     switch (pluralCase) {
       case PluralCase.ZERO:
@@ -186,7 +194,8 @@ class Localization {
     if (subKey == 'other') return _resolve('$key.other');
 
     final tag = '$key.$subKey';
-    var resource = _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
+    var resource =
+        _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
     if (resource == tag) {
       resource = _resolve('$key.other');
     }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -20,7 +20,7 @@ class Localization {
   };
 
   bool _useFallbackTranslationsForEmptyResources = false;
-  bool _forcePluralCaseFallback = false;
+  bool _ignorePluralRules = false;
 
   Localization();
 
@@ -36,14 +36,14 @@ class Localization {
     Translations? translations,
     Translations? fallbackTranslations,
     bool useFallbackTranslationsForEmptyResources = false,
-    bool forcePluralCaseFallback = false,
+    bool ignorePluralRules = false,
   }) {
     instance._locale = locale;
     instance._translations = translations;
     instance._fallbackTranslations = fallbackTranslations;
     instance._useFallbackTranslationsForEmptyResources =
         useFallbackTranslationsForEmptyResources;
-    instance._forcePluralCaseFallback = forcePluralCaseFallback;
+    instance._ignorePluralRules = ignorePluralRules;
     return translations == null ? false : true;
   }
 
@@ -119,7 +119,7 @@ class Localization {
   }
 
   static PluralRule? _pluralRule(String? locale, num howMany) {
-    if (instance._forcePluralCaseFallback) {
+    if (!instance._ignorePluralRules) {
       return () => _pluralCaseFallback(howMany);
     }
     startRuleEvaluation(howMany);

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -150,8 +150,7 @@ class Localization {
     late String res;
 
     final pluralRule = _pluralRule(_locale.languageCode, value);
-    final pluralCase =
-        pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
+    final pluralCase = pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
 
     switch (pluralCase) {
       case PluralCase.ZERO:
@@ -194,8 +193,7 @@ class Localization {
     if (subKey == 'other') return _resolve('$key.other');
 
     final tag = '$key.$subKey';
-    var resource =
-        _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
+    var resource = _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
     if (resource == tag) {
       resource = _resolve('$key.other');
     }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -36,7 +36,7 @@ class Localization {
     Translations? translations,
     Translations? fallbackTranslations,
     bool useFallbackTranslationsForEmptyResources = false,
-    bool ignorePluralRules = false,
+    bool ignorePluralRules = true,
   }) {
     instance._locale = locale;
     instance._translations = translations;
@@ -119,7 +119,7 @@ class Localization {
   }
 
   static PluralRule? _pluralRule(String? locale, num howMany) {
-    if (!instance._ignorePluralRules) {
+    if (instance._ignorePluralRules) {
       return () => _pluralCaseFallback(howMany);
     }
     startRuleEvaluation(howMany);

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -48,7 +48,7 @@ void main() {
       Localization.load(const Locale('en'),
           translations: r.translations,
           fallbackTranslations: r.fallbackTranslations,
-          ignorePluralRules: true);
+          ignorePluralRules: false);
       expect(Localization.instance.plural('hat', 2), 'other hats');
       expect(Localization.instance.plural('hat', 0), 'other hats');
       expect(Localization.instance.plural('hat', 3), 'other hats');
@@ -70,7 +70,7 @@ void main() {
       Localization.load(const Locale('ru'),
           translations: r.translations,
           fallbackTranslations: r.fallbackTranslations,
-          ignorePluralRules: true);
+          ignorePluralRules: false);
       expect(Localization.instance.plural('hat', 2), 'few hats');
       expect(Localization.instance.plural('hat', 3), 'few hats');
     });
@@ -85,7 +85,7 @@ void main() {
       Localization.load(const Locale('ru'),
           translations: r.translations,
           fallbackTranslations: r.fallbackTranslations,
-          ignorePluralRules: true);
+          ignorePluralRules: false);
       expect(Localization.instance.plural('hat', 0), 'many hats');
       expect(Localization.instance.plural('hat', 5), 'many hats');
     });

--- a/test/easy_localization_language_specific_test.dart
+++ b/test/easy_localization_language_specific_test.dart
@@ -8,58 +8,86 @@ import 'package:flutter_test/flutter_test.dart';
 import 'utils/test_asset_loaders.dart';
 
 void main() {
-    group('language-specific-plurals', () {
-      var r = EasyLocalizationController(
-          forceLocale: const Locale('fb'),
-          supportedLocales: [const Locale('en'), const Locale('ru'), const Locale('fb')],
-          fallbackLocale: const Locale('fb'),
-          path: 'path',
-          useOnlyLangCode: true,
-          useFallbackTranslations: true,
-          onLoadError: (FlutterError e) {
-            log(e.toString());
-          },
-          saveLocale: false,
-          assetLoader: const JsonAssetLoader());
+  group('language-specific-plurals', () {
+    var r = EasyLocalizationController(
+        forceLocale: const Locale('fb'),
+        supportedLocales: [
+          const Locale('en'),
+          const Locale('ru'),
+          const Locale('fb')
+        ],
+        fallbackLocale: const Locale('fb'),
+        path: 'path',
+        useOnlyLangCode: true,
+        useFallbackTranslations: true,
+        onLoadError: (FlutterError e) {
+          log(e.toString());
+        },
+        saveLocale: false,
+        assetLoader: const JsonAssetLoader());
 
-      setUpAll(() async {
-        await r.loadTranslations();
-        
-      });
-
-      test('english one', () async {
-        Localization.load(const Locale('en'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 1), 'one hat');
-      }); 
-      test('english other', () async {
-        Localization.load(const Locale('en'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 2), 'other hats');
-        expect(Localization.instance.plural('hat', 0), 'other hats');
-        expect(Localization.instance.plural('hat', 3), 'other hats');
-      }); 
-      test('russian one', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 1), 'one hat');
-      }); 
-      test('russian few', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 2), 'few hats');
-        expect(Localization.instance.plural('hat', 3), 'few hats');
-      });
-      test('russian many', () async {
-        Localization.load(const Locale('ru'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
-        expect(Localization.instance.plural('hat', 0), 'many hats');
-        expect(Localization.instance.plural('hat', 5), 'many hats');
-      });
+    setUpAll(() async {
+      await r.loadTranslations();
     });
+
+    test('english one', () async {
+      Localization.load(const Locale('en'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 1), 'one hat');
+    });
+    test('english other (default)', () async {
+      Localization.load(const Locale('en'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 2), 'two hats');
+      expect(Localization.instance.plural('hat', 0), 'no hats');
+      expect(Localization.instance.plural('hat', 3), 'other hats');
+    });
+    test('english other (with ignorePluralRules)', () async {
+      Localization.load(const Locale('en'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations,
+          ignorePluralRules: true);
+      expect(Localization.instance.plural('hat', 2), 'other hats');
+      expect(Localization.instance.plural('hat', 0), 'other hats');
+      expect(Localization.instance.plural('hat', 3), 'other hats');
+    });
+    test('russian one', () async {
+      Localization.load(const Locale('ru'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 1), 'one hat');
+    });
+    test('russian few (default)', () async {
+      Localization.load(const Locale('ru'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 2), 'two hats');
+      expect(Localization.instance.plural('hat', 3), 'other hats');
+    });
+    test('russian few (with ignorePluralRules)', () async {
+      Localization.load(const Locale('ru'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations,
+          ignorePluralRules: true);
+      expect(Localization.instance.plural('hat', 2), 'few hats');
+      expect(Localization.instance.plural('hat', 3), 'few hats');
+    });
+    test('russian many (default)', () async {
+      Localization.load(const Locale('ru'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations);
+      expect(Localization.instance.plural('hat', 0), 'no hats');
+      expect(Localization.instance.plural('hat', 5), 'other hats');
+    });
+    test('russian many (with ignorePluralRules)', () async {
+      Localization.load(const Locale('ru'),
+          translations: r.translations,
+          fallbackTranslations: r.fallbackTranslations,
+          ignorePluralRules: true);
+      expect(Localization.instance.plural('hat', 0), 'many hats');
+      expect(Localization.instance.plural('hat', 5), 'many hats');
+    });
+  });
 }

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -285,7 +285,7 @@ void main() async {
         await tester.pumpWidget(EasyLocalization(
           path: '../../i18n',
           supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
-          ignorePluralRules: true,
+          ignorePluralRules: false,
           child: const MyApp(),
         ));
 

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -5,9 +5,9 @@ import 'package:easy_localization/src/exceptions.dart';
 import 'package:easy_localization/src/localization.dart';
 import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'utils/test_asset_loaders.dart';
 
 late BuildContext _context;
@@ -285,6 +285,7 @@ void main() async {
         await tester.pumpWidget(EasyLocalization(
           path: '../../i18n',
           supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
+          ignorePluralRules: true,
           child: const MyApp(),
         ));
 
@@ -297,8 +298,10 @@ void main() async {
 
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [
+          const Locale('en', 'US'),
+          const Locale('ar', 'DZ'),
+        ]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
 
         var trFinder = find.text('اختبار');


### PR DESCRIPTION
Add forcePluralCaseFallback option to force evaluation of fallback plural rules, i.e.
    
`forcePluralCaseFallback: false`
Default behavior, will use "zero" rule for 0 only if the language is set to do so (e.g. for "lt" but not for "en").
    
`forcePluralCaseFallback: true`
Force using "zero" rule for 0 even if the language doesn't use it by default (e.g. "en"). If "zero" localization for that string doesn't exist, "other" is still used as fallback.
