### PR TITLE
Export localization

### DIFF
--- a/lib/easy_localization.dart
+++ b/lib/easy_localization.dart
@@ -4,4 +4,5 @@ export 'package:easy_localization/src/easy_localization_app.dart';
 export 'package:easy_localization/src/asset_loader.dart';
 export 'package:easy_localization/src/public.dart';
 export 'package:easy_localization/src/public_ext.dart';
+export 'package:easy_localization/src/localization.dart';
 export 'package:intl/intl.dart';


### PR DESCRIPTION
Export the `Localization` class so that `Localization.instance` can be accessed and used in a Dart isolate

Issue: https://github.com/aissat/easy_localization/issues/210#issuecomment-2082589871