### PR TITLE
add _supportedLocales in EasyLocalizationController; check the device…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### [3.0.6]
 
 - add 'useFallbackTranslationsForEmptyResources' to be able to use fallback locales for empty resources.
+- add _supportedLocales in EasyLocalizationController; log and check the deviceLocale when resetLocale;
 
 ### [3.0.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - add 'useFallbackTranslationsForEmptyResources' to be able to use fallback locales for empty resources.
 - add _supportedLocales in EasyLocalizationController; log and check the deviceLocale when resetLocale;
+- add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant
 
 ### [3.0.5]
 

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -12,6 +12,7 @@ class EasyLocalizationController extends ChangeNotifier {
 
   late Locale _locale;
   Locale? _fallbackLocale;
+  List<Locale>? _supportedLocales;
 
   final Function(FlutterError e) onLoadError;
   final AssetLoader assetLoader;
@@ -38,6 +39,7 @@ class EasyLocalizationController extends ChangeNotifier {
     Locale? forceLocale, // used for testing
   }) {
     _fallbackLocale = fallbackLocale;
+    _supportedLocales = supportedLocales;
     if (forceLocale != null) {
       _locale = forceLocale;
     } else if (_savedLocale == null && startLocale != null) {
@@ -144,8 +146,9 @@ class EasyLocalizationController extends ChangeNotifier {
     final result = <String, dynamic>{};
     final loaderFutures = <Future<Map<String, dynamic>?>>[];
 
+    // need scriptCode, it might be better to use ignoreCountryCode as the variable name of useOnlyLangCode 
     final Locale desiredLocale =
-        useOnlyLangCode ? Locale(locale.languageCode) : locale;
+        useOnlyLangCode ? Locale.fromSubtags(languageCode: locale.languageCode, scriptCode: locale.scriptCode) : locale;
 
     List<AssetLoader> loaders = [
       assetLoader,
@@ -205,7 +208,8 @@ class EasyLocalizationController extends ChangeNotifier {
   Future<void> resetLocale() async {
     EasyLocalization.logger('Reset locale to platform locale $_deviceLocale');
 
-    await setLocale(_deviceLocale);
+    final locale = selectLocaleFrom(_supportedLocales!, deviceLocale, fallbackLocale: _fallbackLocale);
+    await setLocale(locale);
   }
 }
 

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -206,9 +206,9 @@ class EasyLocalizationController extends ChangeNotifier {
   Locale get deviceLocale => _deviceLocale;
 
   Future<void> resetLocale() async {
-    EasyLocalization.logger('Reset locale to platform locale $_deviceLocale');
-
     final locale = selectLocaleFrom(_supportedLocales!, deviceLocale, fallbackLocale: _fallbackLocale);
+
+    EasyLocalization.logger('Reset locale to $locale while the platform locale is $_deviceLocale and the fallback locale is $_fallbackLocale');
     await setLocale(locale);
   }
 }


### PR DESCRIPTION
add _supportedLocales in EasyLocalizationController; check the deviceLocale in resetLocale; 
--
to fix this [issue](https://github.com/aissat/easy_localization/issues/670)

add scriptCode if useOnlyLangCode
--
scriptCode is needed sometimes, for example zh-Hans, zh-Hant