### PR TITLE
add savedLocale get method for context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add 'useFallbackTranslationsForEmptyResources' to be able to use fallback locales for empty resources.
 - add _supportedLocales in EasyLocalizationController; log and check the deviceLocale when resetLocale;
 - add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant
+- add savedLocale get method for context. if context.savedLocale is null, then language option is `following system`, i can display the option in user selection form.
 
 ### [3.0.5]
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -261,6 +261,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   /// Getting device locale from platform
   Locale get deviceLocale => _localeState.deviceLocale;
+  Locale? get savedLocale => _localeState.savedLocale;
 
   /// Reset locale to platform locale
   Future<void> resetLocale() => _localeState.resetLocale();

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -204,6 +204,7 @@ class EasyLocalizationController extends ChangeNotifier {
   }
 
   Locale get deviceLocale => _deviceLocale;
+  Locale? get savedLocale => _savedLocale;
 
   Future<void> resetLocale() async {
     final locale = selectLocaleFrom(_supportedLocales!, deviceLocale, fallbackLocale: _fallbackLocale);

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -165,6 +165,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
 
   /// Getting device locale from platform
   Locale get deviceLocale => EasyLocalization.of(this)!.deviceLocale;
+  Locale? get savedLocale => EasyLocalization.of(this)!.savedLocale;
 
   /// Reset locale to platform locale
   Future<void> resetLocale() => EasyLocalization.of(this)!.resetLocale();


### PR DESCRIPTION
if context.savedLocale is null, then language option is `following system`, i can display the option in user selection form.

And after set to another locale by user selection, i use the following code to reset it to `following system`
```
                await context.resetLocale();
                context.deleteSaveLocale();
```