### PR TITLE
assign _savedLocale when _saveLocal()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add 'useFallbackTranslationsForEmptyResources' to be able to use fallback locales for empty resources.
 - add _supportedLocales in EasyLocalizationController; log and check the deviceLocale when resetLocale;
 - add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant
+- add savedLocale get method for context. if context.savedLocale is null, then language option is `following system`, i can display the option in user selection form.
 
 ### [3.0.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - add _supportedLocales in EasyLocalizationController; log and check the deviceLocale when resetLocale;
 - add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant
 - add savedLocale get method for context. if context.savedLocale is null, then language option is `following system`, i can display the option in user selection form.
+- fix the bug: _savedLocale not assigned in _saveLocale(), and notify listeners after _saveLocale() because _savedLocale might be needed
 
 ### [3.0.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant
 - add savedLocale get method for context. if context.savedLocale is null, then language option is `following system`, i can display the option in user selection form.
 - fix the bug: _savedLocale not assigned in _saveLocale(), and notify listeners after _saveLocale() because _savedLocale might be needed
+- saveLocale even if the locale not changed, when using _savedLocale as `following system` option and currently system language is en, then change the locale from system to en, won't really change the locale but needs to store it to distinguish the difference of `system` and `english`
+- `shouldReload(LocalizationsDelegate<Localization> old)` return true, the LocalizationsDelegate does not reload when return false, tested in my current configuration.
 
 ### [3.0.5]
 

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -261,6 +261,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   /// Getting device locale from platform
   Locale get deviceLocale => _localeState.deviceLocale;
+  Locale? get savedLocale => _localeState.savedLocale;
 
   /// Reset locale to platform locale
   Future<void> resetLocale() => _localeState.resetLocale();

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -252,6 +252,15 @@ class _EasyLocalizationProvider extends InheritedWidget {
       assert(parent.supportedLocales.contains(locale));
       await _localeState.setLocale(locale);
     }
+    else {
+      // given current language en (option is following system, en is the system language)
+      // then set the locale to en won't change the locale
+      // but needs change the savedLocale
+      // savedLocale == null will give a language following the system
+      // savedLocale == Locale('en') will give english
+      assert(parent.supportedLocales.contains(locale));
+      await _localeState.storeLocale(locale);
+    }
   }
 
   /// Clears a saved locale from device storage
@@ -312,5 +321,5 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   }
 
   @override
-  bool shouldReload(LocalizationsDelegate<Localization> old) => false;
+  bool shouldReload(LocalizationsDelegate<Localization> old) => true;
 }

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -204,6 +204,7 @@ class EasyLocalizationController extends ChangeNotifier {
   }
 
   Locale get deviceLocale => _deviceLocale;
+  Locale? get savedLocale => _savedLocale;
 
   Future<void> resetLocale() async {
     final locale = selectLocaleFrom(_supportedLocales!, deviceLocale, fallbackLocale: _fallbackLocale);

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -180,6 +180,11 @@ class EasyLocalizationController extends ChangeNotifier {
     notifyListeners();
   }
 
+  // avoid name conflict with the variable saveLocale
+  Future<void> storeLocale(Locale? locale) async {
+    await _saveLocale(_locale);
+  }
+
   Future<void> _saveLocale(Locale? locale) async {
     if (!saveLocale) return;
     _savedLocale = locale;

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -174,14 +174,15 @@ class EasyLocalizationController extends ChangeNotifier {
 
   Future<void> setLocale(Locale l) async {
     _locale = l;
-    await loadTranslations();
-    notifyListeners();
     EasyLocalization.logger('Locale $locale changed');
     await _saveLocale(_locale);
+    await loadTranslations();
+    notifyListeners();
   }
 
   Future<void> _saveLocale(Locale? locale) async {
     if (!saveLocale) return;
+    _savedLocale = locale;
     final preferences = await SharedPreferences.getInstance();
     await preferences.setString('locale', locale.toString());
     EasyLocalization.logger('Locale $locale saved');

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -165,6 +165,7 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
 
   /// Getting device locale from platform
   Locale get deviceLocale => EasyLocalization.of(this)!.deviceLocale;
+  Locale? get savedLocale => EasyLocalization.of(this)!.savedLocale;
 
   /// Reset locale to platform locale
   Future<void> resetLocale() => EasyLocalization.of(this)!.resetLocale();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: '>=2.0.0 <3.0.0'
-  intl: '>=0.17.0-0 <=0.20.1'
+  intl: '>=0.17.0-0 <=0.20.2'
   args: ^2.3.1
   path: ^1.8.1
   easy_logger: ^0.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: '>=2.0.0 <3.0.0'
-  intl: '>=0.17.0-0 <=0.19.0'
+  intl: '>=0.17.0-0 <=0.20.1'
   args: ^2.3.1
   path: ^1.8.1
   easy_logger: ^0.0.2


### PR DESCRIPTION
assgin _savedLocale = locale when _saveLocale(); 
notify listeners after _saveLocale becaused it's needed by the ui
changelog added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with locale saving and notification to ensure updates are properly reflected in the app.
  * Fixed behavior when selecting a locale that matches the system language, allowing explicit user selection to be recognized.
  * Ensured localization resources always reload when needed.

* **Chores**
  * Updated dependency version constraints to support newer versions of the intl package.
  * Updated changelog to reflect recent fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->