### PR TITLE
Remove banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Stand With Palestine](https://raw.githubusercontent.com/TheBSD/StandWithPalestine/main/banner-no-action.svg)](https://thebsd.github.io/StandWithPalestine)
-
 <p align="center"><img src="https://raw.githubusercontent.com/aissat/easy_localization/develop/logo/logo.svg?sanitize=true" width="600"/></p>
 <h1 align="center"> 
 Easy and Fast internationalization for your Flutter Apps


### PR DESCRIPTION
The Palestine banner at the top of the README file was added a few months ago. I understand and respect that this is a very important topic for you @aissat, and since you are the inventor and most important maintainer of this project, I did not say anything about it.

However, I would like to discuss the possibility of keeping our project’s main page focused strictly on the technical aspects and functionalities of the package.

The open-source community thrives on collaboration from individuals around the world. Even if two nations are at war with each other, contributors from both nations can work on the same project.

Let's keep our project’s documentation, especially the README, free from political expressions of any kind. This would help us ensure that the project remains a neutral zone, focused solely on development and innovation.

I hope that we can discuss this *without* diving into the topic itself.