### PR TITLE
Ignore _savedLocale on start when saveLocale is false (#430)

### DIFF
--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -42,7 +42,7 @@ class EasyLocalizationController extends ChangeNotifier {
     _supportedLocales = supportedLocales;
     if (forceLocale != null) {
       _locale = forceLocale;
-    } else if (_savedLocale == null && startLocale != null) {
+    } else if ((!saveLocale || _savedLocale == null) && startLocale != null) {
       _locale = _getFallbackLocale(supportedLocales, startLocale);
       EasyLocalization.logger('Start locale loaded ${_locale.toString()}');
     }


### PR DESCRIPTION
Always use startLocale when it's provided and saveLocale is false. Fixes #430 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved initial language selection: when saving is enabled and a saved language exists, the app now starts in the saved language instead of the configured start language.
  - If saving is disabled or no saved language exists, the app falls back to the configured start language, otherwise to the device language.
  - No behavior changes to logs or settings screens. No public API changes. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->