### PR TITLE
chore: Ignore constant identifier names

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -234,7 +234,7 @@ Future _writeJson(
   var gFile = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
-// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters
+// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters, constant_identifier_names
 
 import 'dart:ui';
 


### PR DESCRIPTION
fix lowerCamelCase linter warning to generated files