### PR TITLE
add constant_identifier_names to generated files

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -234,7 +234,7 @@ Future _writeJson(
   var gFile = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
-// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters
+// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters, constant_identifier_names
 
 import 'dart:ui';
 

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -175,6 +175,8 @@ Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
+// ignore_for_file: constant_identifier_names
+
 abstract class  LocaleKeys {
 ''';
 


### PR DESCRIPTION
avoid linter warnings to generated files