### PR TITLE
support Json List

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -263,6 +263,8 @@ class CodegenLoader extends AssetLoader{
 
     final result = json.decode(await fileData.readAsString());
 
+
+
     Map<String, dynamic>? data = result is List<dynamic>
         ? convertJsonListToMap(result)
         : result;


### PR DESCRIPTION
Easy localization can only recognize json files with a json map structure.

However, not all json files have a map structure.

Modified to recognize json file of json list type.

If the row of the json list is a json map, the first key of the map's key iterator is used to store 
the row as a key and value in the json map.


thanks.