### PR TITLE
Feature: Custom code gen class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### [3.0.9]
+
+- Added custom class name option for code generation (`--class-name` or `-c` parameter)
+
 ### [3.0.8]
 
 - code audit and maintenance updates
@@ -51,9 +55,11 @@
 - **BREAKING**: removed context parameter from `plural()` and `tr()`
 - Added Formatting linked translations [more](https://github.com/aissat/easy_localization#linked-translations)
 - Updated `plural()` function, with arguments [more](https://github.com/aissat/easy_localization#linked-translations)
+
   ```dart
     var money = plural('money_args', 10.23, args: ['John', '10.23'])  // output: John has 10.23 dollars
   ```
+
 - Removed preloader widget ~~`preloaderWidget`~~
 - fixed many issues.
 - customizable logger [EasyLogger]
@@ -84,6 +90,7 @@
 ```dart
 context.locale = locale;
 ```
+
 :information_source: No breaking changes, you can use old the static method `EasyLocalization.of(context)`
 
 ### [2.2.2]

--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Code generation supports only json files, for more information run in terminal `
 | --output-dir                 | -O    | lib/generated         | Output folder stores for the generated file                                 |
 | --output-file                | -o    | codegen_loader.g.dart | Output file name                                                            |
 | --format                     | -f    | json                  | Support json or keys formats                                                |
+| --class-name                 | -c    | LocaleKeys            | Custom class name for generated keys class                                  |
 | --[no-]skip-unnecessary-keys | -u    | false                 | Ignores keys defining nested object except for pluarl(), gender() keywords. |
 
 ### 🔌 Localization asset loader class

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -115,8 +115,6 @@ void handleLangFiles(GenerateOptions options) async {
   final sourcePath = Directory(path.join(current.path, source.path));
   final outputPath =
       Directory(path.join(current.path, output.path, options.outputFile));
-  final className = options.className ?? 'LocaleKeys';
-
   if (!await sourcePath.exists()) {
     stderr.writeln('Source path does not exist');
     return;
@@ -136,7 +134,7 @@ void handleLangFiles(GenerateOptions options) async {
   }
 
   if (files.isNotEmpty) {
-    generateFile(files, outputPath, options, className);
+    generateFile(files, outputPath, options);
   } else {
     stderr.writeln('Source path empty');
   }
@@ -155,8 +153,8 @@ void generateFile(
   List<FileSystemEntity> files,
   Directory outputPath,
   GenerateOptions options,
-  String className,
 ) async {
+  final className = options.className ?? 'LocaleKeys';
   var generatedFile = File(outputPath.path);
   if (!generatedFile.existsSync()) {
     generatedFile.createSync(recursive: true);

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -85,8 +85,8 @@ ArgParser _generateArgParser(GenerateOptions? generateOptions) {
     'class-name',
     abbr: 'c',
     defaultsTo: 'LocaleKeys',
-    callback: (String? x) => generateOptions!.className = x!,
-    help: 'Custom class name for generated file',
+    callback: (String? x) => generateOptions!.className = x,
+    help: 'Custom class name for generated keys class (keys format)',
   );
 
   return parser;
@@ -104,7 +104,13 @@ class GenerateOptions {
 
   @override
   String toString() {
-    return 'format: $format sourceDir: $sourceDir sourceFile: $sourceFile outputDir: $outputDir outputFile: $outputFile skipUnnecessaryKeys: $skipUnnecessaryKeys';
+    return 'format: $format '
+        'sourceDir: $sourceDir '
+        'sourceFile: $sourceFile '
+        'outputDir: $outputDir '
+        'outputFile: $outputFile '
+        'skipUnnecessaryKeys: $skipUnnecessaryKeys '
+        'className: $className';
   }
 }
 
@@ -194,7 +200,7 @@ Future _writeKeys(
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  $className {
+abstract class $className {
 ''';
 
   final fileData = File(files.first.path);

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -192,6 +192,8 @@ Future _writeKeys(
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
+// ignore_for_file: constant_identifier_names
+
 abstract class  $className {
 ''';
 
@@ -251,7 +253,7 @@ Future _writeJson(
   var gFile = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
-// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters
+// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters, constant_identifier_names
 
 import 'dart:ui';
 
@@ -272,13 +274,13 @@ class CodegenLoader extends AssetLoader{
   for (var file in files) {
     final localeName =
         path.basename(file.path).replaceFirst('.json', '').replaceAll('-', '_');
-    listLocales.add('"$localeName": $localeName');
+    listLocales.add('"$localeName": _$localeName');
     final fileData = File(file.path);
 
     Map<String, dynamic>? data = json.decode(await fileData.readAsString());
 
     final mapString = const JsonEncoder.withIndent('  ').convert(data);
-    gFile += 'static const Map<String,dynamic> $localeName = $mapString;\n';
+    gFile += 'static const Map<String,dynamic> _$localeName = $mapString;\n';
   }
 
   gFile +=

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/aissat/easy_localization
 issue_tracker: https://github.com/aissat/easy_localization/issues
 # publish_to: none
 
-version: 3.0.8
+version: 3.0.9
 
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
Hi, this is needed when we import localizations from multiple packages.
https://github.com/aissat/easy_localization/issues/449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option --class-name (-c) to set a custom name for the generated keys class.
  * Generated output now uses the chosen class name; defaults to LocaleKeys when not provided.
  * CLI help and tool output now reflect and include the chosen class name option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->