### PR TITLE
feat: Adding the possibility to pass a localization delegate to EasyLocalization widget

### DIFF
--- a/lib/easy_localization.dart
+++ b/lib/easy_localization.dart
@@ -4,4 +4,6 @@ export 'package:easy_localization/src/easy_localization_app.dart';
 export 'package:easy_localization/src/asset_loader.dart';
 export 'package:easy_localization/src/public.dart';
 export 'package:easy_localization/src/public_ext.dart';
+export 'package:easy_localization/src/easy_localization_controller.dart';
+export 'package:easy_localization/src/localization.dart';
 export 'package:intl/intl.dart';


### PR DESCRIPTION
Hi, 
in order to give the possibility to customize the loading of the delegate i propose this changes that are backward compatible and give the possibility to implement a custom localization delegate and pass it to the EasyLocalization widget.

The new parameter is optional and doesn't break existing logic of the previous implementations. 