### PR TITLE
feat: add support for rich text

### DIFF
--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -9,6 +9,7 @@ class Localization {
   late Locale _locale;
 
   final RegExp _replaceArgRegex = RegExp('{}');
+  final RegExp _namedArgMatcher = RegExp('({([a-zA-Z0-9_]+)})');
   final RegExp _linkKeyMatcher =
       RegExp(r'(?:@(?:\.[a-z]+)?:(?:[\w\-_|.]+|\([\w\-_|.]+\)))');
   final RegExp _linkKeyPrefixMatcher = RegExp(r'^@(?:\.([a-z]+))?:');
@@ -68,6 +69,27 @@ class Localization {
     return _replaceArgs(res, args);
   }
 
+  TextSpan trSpan(
+    String key, {
+    Map<String, TextSpan>? namedArgs,
+    String? gender,
+  }) {
+    late String res;
+    late TextSpan span;
+
+    if (gender != null) {
+      res = _gender(key, gender: gender);
+    } else {
+      res = _resolve(key);
+    }
+
+    res = _replaceLinks(res);
+
+    span = _replaceSpanNamedArgs(res, namedArgs);
+
+    return span;
+  }
+
   String _replaceLinks(String res, {bool logging = true}) {
     // TODO: add recursion detection and a resolve stack.
     final matches = _linkKeyMatcher.allMatches(res);
@@ -103,6 +125,24 @@ class Localization {
     return result;
   }
 
+  List<String> _splitTextWithNamedArg(String text) {
+    final matches = _namedArgMatcher.allMatches(text);
+    var lastIndex = 0;
+    final result = <String>[];
+
+    for (final match in matches) {
+      result
+        ..add(text.substring(lastIndex, match.start))
+        ..add(match.group(0) ?? '');
+      lastIndex = match.end;
+    }
+    if (lastIndex < text.length) {
+      result.add(text.substring(lastIndex));
+    }
+
+    return result;
+  }
+
   String _replaceArgs(String res, List<String>? args) {
     if (args == null || args.isEmpty) return res;
     for (var str in args) {
@@ -116,6 +156,16 @@ class Localization {
     args.forEach((String key, String value) =>
         res = res.replaceAll(RegExp('{$key}'), value));
     return res;
+  }
+
+
+  TextSpan _replaceSpanNamedArgs(String res, Map<String, TextSpan>? args) {
+    if (args == null || args.isEmpty) return TextSpan(text: res);
+    final spans = _splitTextWithNamedArg(res).map((part) {
+      final key = part.replaceAll(RegExp(r'^\{|\}$'), '');
+      return args[key] ?? TextSpan(text: part);
+    }).toList();
+    return TextSpan(children: spans);
   }
 
   static PluralRule? _pluralRule(String? locale, num howMany) {
@@ -150,7 +200,8 @@ class Localization {
     late String res;
 
     final pluralRule = _pluralRule(_locale.languageCode, value);
-    final pluralCase = pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
+    final pluralCase =
+        pluralRule != null ? pluralRule() : _pluralCaseFallback(value);
 
     switch (pluralCase) {
       case PluralCase.ZERO:
@@ -193,7 +244,8 @@ class Localization {
     if (subKey == 'other') return _resolve('$key.other');
 
     final tag = '$key.$subKey';
-    var resource = _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
+    var resource =
+        _resolve(tag, logging: false, fallback: _fallbackTranslations != null);
     if (resource == tag) {
       resource = _resolve('$key.other');
     }

--- a/lib/src/localization.dart
+++ b/lib/src/localization.dart
@@ -72,16 +72,11 @@ class Localization {
   TextSpan trSpan(
     String key, {
     Map<String, TextSpan>? namedArgs,
-    String? gender,
   }) {
     late String res;
     late TextSpan span;
 
-    if (gender != null) {
-      res = _gender(key, gender: gender);
-    } else {
-      res = _resolve(key);
-    }
+    res = _resolve(key);
 
     res = _replaceLinks(res);
 
@@ -157,7 +152,6 @@ class Localization {
         res = res.replaceAll(RegExp('{$key}'), value));
     return res;
   }
-
 
   TextSpan _replaceSpanNamedArgs(String res, Map<String, TextSpan>? args) {
     if (args == null || args.isEmpty) return TextSpan(text: res);

--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -45,9 +45,36 @@ String tr(
           .tr(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
+/// {@template trSpan}
+/// function for translate your language keys
+/// [key] Localization key
+/// [BuildContext] The location in the tree where this widget builds
+/// [namedArgs] Map of localized strings. Replaces the name keys {key_name} with [TextSpan]
+///
+/// Example:
+///
+/// ```json
+/// {
+///    "msg_named":"Easy localization is written in the {lang} language"
+/// }
+/// ```
+/// ```dart
+/// Text.rich(trSpan('msg_named',namedArgs: {'lang': TextSpan(text: 'Dart')})),
+/// ```
+/// {@endtemplate}
+
+TextSpan trSpan(
+  String key, {
+  BuildContext? context,
+  Map<String, TextSpan>? namedArgs,
+}) {
+  return context != null
+      ? Localization.of(context)!.trSpan(key, namedArgs: namedArgs)
+      : Localization.instance.trSpan(key, namedArgs: namedArgs);
+}
+
 bool trExists(String key) {
-  return Localization.instance
-      .exists(key);
+  return Localization.instance.exists(key);
 }
 
 /// {@template plural}

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -219,6 +219,22 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     );
   }
 
+  TextSpan trSpan(
+    String key, {
+    Map<String, TextSpan>? namedArgs,
+  }) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw const LocalizationNotFoundException();
+    }
+
+    return localization.trSpan(
+      key,
+      namedArgs: namedArgs,
+    );
+  }
+
   String plural(
     String key,
     num number, {


### PR DESCRIPTION
Hi, 
currently the package doesn't support for `RichText` or `Text.Rich` so I propose to add the function called `trSpan`, which is it will return `TextSpan` as result

this example to use this function
```json
 {
    "msg_named":"Easy localization is written in the {lang} language"
 }
```



```dart
Text.rich(trSpan('msg_named',namedArgs: {'lang': TextSpan(text: 'Dart')}))
```
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `trSpan` method for translating localization keys into `TextSpan` objects, enhancing text formatting capabilities.
	- Added support for named arguments in localization strings through new methods in the `Localization` class.
	- Updated `BuildContextEasyLocalizationExtension` to include `trSpan` for improved localization handling.

- **Documentation**
	- Enhanced comments and documentation for existing methods to clarify usage and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->