### PR TITLE
Pump intl library version to 0.20.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: '>=2.0.0 <3.0.0'
-  intl: '>=0.17.0-0 <=0.19.0'
+  intl: '>=0.17.0-0 <=0.20.0'
   args: ^2.3.1
   path: ^1.8.1
   easy_logger: ^0.0.2


### PR DESCRIPTION
A small change to pump the intl library version to 0.20.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `intl` dependency in the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->