### PR TITLE
Align trExists API with tr/plural

### DIFF
--- a/lib/src/public.dart
+++ b/lib/src/public.dart
@@ -45,9 +45,12 @@ String tr(
           .tr(key, args: args, namedArgs: namedArgs, gender: gender);
 }
 
-bool trExists(String key) {
-  return Localization.instance
-      .exists(key);
+bool trExists(String key, {BuildContext? context}) {
+  return context != null
+      ? Localization.of(context)!
+	      .exists(key)
+      : Localization.instance
+	      .exists(key);
 }
 
 /// {@template plural}

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -90,7 +90,7 @@ extension StringTranslateExtension on String {
       ez.tr(this,
           context: context, args: args, namedArgs: namedArgs, gender: gender);
 
-  bool trExists() => ez.trExists(this);
+  bool trExists({BuildContext? context}) => ez.trExists(this, context: context);
 
   /// {@macro plural}
   String plural(

--- a/lib/src/public_ext.dart
+++ b/lib/src/public_ext.dart
@@ -219,6 +219,16 @@ extension BuildContextEasyLocalizationExtension on BuildContext {
     );
   }
 
+  bool trExists(String key) {
+    final localization = Localization.of(this);
+
+    if (localization == null) {
+      throw const LocalizationNotFoundException();
+    }
+
+    return localization.exists(key);
+  }
+
   String plural(
     String key,
     num number, {

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -716,6 +716,10 @@ void main() {
         test('tr', () {
           expect(tr('test'), 'test');
         });
+        test('trExists', () {
+          expect(trExists('test'), true);
+          expect(trExists('xyz'), false);
+        });
         test('plural', () {
           expect(plural('day', 0), '0 days');
         });


### PR DESCRIPTION
Thanks for this useful library!

This PR adds some missing parts for `trExists` function:
- `trExists` should accept `context` as an argument (similar to `tr` and `plural` API)
- `trExists` was available as a standalone function and as a `String` extension previously. This PR also extends `BuildContext` with it (similar to `tr` and `plural`).

Without a context, `trExists` function would have an issue similar to #448 and #552.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced localization functionality by adding optional context parameter to `trExists` method
	- Improved translation key existence checking across different contexts

- **Tests**
	- Added test case to verify translation key existence functionality

The changes provide more flexible localization support, allowing developers to check translation key existence with or without a specific context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->