### PR TITLE
fix: Bumped intl version to make package compatible with Flutter 3.27.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: '>=2.0.0 <3.0.0'
-  intl: '>=0.17.0-0 <=0.20.0'
+  intl: '>=0.17.0-0 <0.21.0'
   args: ^2.3.1
   path: ^1.8.1
   easy_logger: ^0.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `intl` package dependency version constraint to allow newer compatible versions while maintaining compatibility with existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->