### PR TITLE
Fix code generation with escaped characters

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -262,7 +262,14 @@ class CodegenLoader extends AssetLoader{
 
     Map<String, dynamic>? data = json.decode(await fileData.readAsString());
 
-    final mapString = const JsonEncoder.withIndent('  ').convert(data);
+    final mapString = StringBuffer();
+    mapString.write('{\n');
+    for (int i = 0; i < (data?.entries.length ?? 0); i++) {
+      final entry = data!.entries.elementAt(i);
+      mapString.write('\t"${entry.key}":"${entry.value}",\n');
+    }
+    mapString.write('}');
+    
     gFile += 'static const Map<String,dynamic> _$localeName = $mapString;\n';
   }
 


### PR DESCRIPTION
When you want to print a text like "The price is $100" we must have a json as follows:

```JSON
{
  "key_name": "The value is \\${price}"
}
```

The generated class will have one extra \ and will make the file to have error.
```DART
static const Map<String,dynamic> _en = {
	"key_name" : "The value is \\${price}",
}
```

This happens because using `JsonEncoder.withIndent('  ').convert(data)` generated a String that is meant to be decoded as JSON and not to be used directly as String. 

By using directly the `entry.value` the `$` will be escaped correctly and the generated code will look like:
```DART
static const Map<String,dynamic> _en = {
	"key_name" : "The value is \${price}",
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the process for generating JSON-formatted localization content, ensuring consistent and structured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->