### PR TITLE
fix: dart format error in generated key class

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -177,7 +177,7 @@ Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  LocaleKeys {
+abstract class LocaleKeys {
 ''';
 
   final fileData = File(files.first.path);


### PR DESCRIPTION
Fixed a double whitespace in the generated language keys resulting in dart format changes in CI/CD workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed an extra space in the declaration of an abstract class to improve code formatting. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->