### PR TITLE
Notify depending widgets when translations are loaded

### DIFF
--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1,5 +1,5 @@
 {
-  "test": "test",
+  "test": "test_en-US",
   "day": {
     "zero": "{} days",
     "one": "{} day",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "test": "test",
+  "test": "test_en",
   "day": {
     "zero": "{} days",
     "one": "{} day",

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -6,7 +6,6 @@ import 'package:easy_logger/easy_logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-import 'asset_loader.dart';
 import 'localization.dart';
 
 part 'utils.dart';
@@ -230,6 +229,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
   final EasyLocalizationController _localeState;
   final Locale? currentLocale;
   final _EasyLocalizationDelegate delegate;
+  final bool _translationsLoaded;
 
   /// {@macro flutter.widgets.widgetsApp.localizationsDelegates}
   ///
@@ -256,6 +256,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
   _EasyLocalizationProvider(this.parent, this._localeState,
       {Key? key, required this.delegate})
       : currentLocale = _localeState.locale,
+        _translationsLoaded = _localeState.translations != null,
         super(key: key, child: parent.child) {
     EasyLocalization.logger.debug('Init provider');
   }
@@ -291,7 +292,8 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_EasyLocalizationProvider oldWidget) {
-    return oldWidget.currentLocale != locale;
+    return oldWidget.currentLocale != locale
+        || oldWidget._translationsLoaded != _translationsLoaded;
   }
 
   static _EasyLocalizationProvider? of(BuildContext context) =>

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -124,6 +124,7 @@ class EasyLocalizationController extends ChangeNotifier {
         }
         _fallbackTranslations = Translations(data);
       }
+      notifyListeners();
     } on FlutterError catch (e) {
       onLoadError(e);
     } catch (e) {

--- a/test/easy_localization_init_test.dart
+++ b/test/easy_localization_init_test.dart
@@ -1,0 +1,77 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_logger/easy_logger.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'easy_localization_context_test.dart';
+
+Future<void> main() async {
+  EasyLocalization.logger.enableLevels = <LevelMessages>[
+    LevelMessages.error,
+    LevelMessages.warning,
+  ];
+
+  SharedPreferences.setMockInitialValues({});
+  EasyLocalization.logger.enableLevels = <LevelMessages>[
+    LevelMessages.error,
+    LevelMessages.warning,
+  ];
+
+  await EasyLocalization.ensureInitialized();
+
+  testWidgets(
+    'Ensure that loading the translations will update its depending widgets',
+    (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(EasyLocalization(
+          supportedLocales: const [Locale('en'), Locale('de')],
+          path: '../../i18n',
+          fallbackLocale: const Locale('en'),
+          child: const I18nObserver(child: MyApp()),
+        ));
+        await tester.pump();
+      });
+    },
+  );
+}
+
+class I18nObserver extends StatefulWidget {
+  final Widget child;
+
+  const I18nObserver({Key? key, required this.child}) : super(key: key);
+
+  @override
+  State<I18nObserver> createState() => _I18nObserverState();
+}
+
+class _I18nObserverState extends State<I18nObserver> {
+  var _firstUpdate = true;
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  @override
+  void didChangeDependencies() {
+    // use the dependOnInheritedWidgetOfExactType pattern
+    EasyLocalization.of(context);
+
+    super.didChangeDependencies();
+
+    if (_firstUpdate) {
+      _firstUpdate = false;
+      expect(
+        'test'.tr(),
+        'test',
+        reason: 'The translation cannot be found yet',
+      );
+    } else {
+      expect(
+        'test'.tr(),
+        'test_en',
+        reason: 'The translation should be loaded on the second call '
+            'of didChangeDependencies()',
+      );
+    }
+  }
+}

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -129,11 +129,11 @@ void main() async {
             [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-        final trFinder = find.text('test');
+        final trFinder = find.text('test_en-US');
         expect(trFinder, findsOneWidget);
         final pluralFinder = find.text('1 day');
         expect(pluralFinder, findsOneWidget);
-        expect(tr('test'), 'test');
+        expect(tr('test'), 'test_en-US');
       });
     },
   );
@@ -155,12 +155,12 @@ void main() async {
             [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-        final trFinder = find.text('test');
+        final trFinder = find.text('test_en-US');
         expect(trFinder, findsOneWidget);
         final pluralFinder = find.text('1 day');
         expect(pluralFinder, findsOneWidget);
 
-        expect(tr('test'), 'test');
+        expect(tr('test'), 'test_en-US');
       });
     },
   );
@@ -205,12 +205,12 @@ void main() async {
         await tester.pump();
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-        final trFinder = find.text('test');
+        final trFinder = find.text('test_en-US');
         expect(trFinder, findsOneWidget);
         final pluralFinder = find.text('1 day');
         expect(pluralFinder, findsOneWidget);
 
-        expect(tr('test'), 'test');
+        expect(tr('test'), 'test_en-US');
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         l = const Locale('ar', 'DZ');
@@ -224,7 +224,7 @@ void main() async {
   );
 
   testWidgets(
-    '[EasyLocalization] change loacle test',
+    '[EasyLocalization] change locale test',
     (WidgetTester tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
@@ -241,12 +241,12 @@ void main() async {
             [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-        var trFinder = find.text('test');
+        var trFinder = find.text('test_en-US');
         expect(trFinder, findsOneWidget);
         var pluralFinder = find.text('1 day');
         expect(pluralFinder, findsOneWidget);
 
-        expect(tr('test'), 'test');
+        expect(tr('test'), 'test_en-US');
 
         var l = const Locale('en', 'US');
         await EasyLocalization.of(_context)!.setLocale(l);
@@ -789,7 +789,7 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(testWidget);
 
-          const expectedEnTranslateTextWidgetValue = 'test';
+          const expectedEnTranslateTextWidgetValue = 'test_en-US';
           const expectedArTranslateTextWidgetValue = 'اختبار';
           const expectedEnPluralTextWidgetValue = '1 day';
           const expectedArPluralTextWidgetValue = '1 يوم';


### PR DESCRIPTION
Fixes #755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured widgets are properly updated when translations are loaded, improving localization update reliability.

- **Tests**
  - Added new tests to verify translation loading and widget updates during initialization.
  - Updated existing tests to match new expected translation values and corrected minor typos in test descriptions.

- **Chores**
  - Updated English localization files with revised translation values for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->