### PR TITLE
[Command] Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,21 @@ print(LocaleKeys.title.tr()); //String
 Text(LocaleKeys.title).tr(); //Widget
 ```
 
+### ✅ Audit missing keys
+
+If you prefer to not generate keys you can see an audit of your translation keys to see the one present in your app code but not in your translations file by running the audit command.
+
+```
+flutter pub run easy_localization:audit
+```
+
+If you are not using the default translations folder path (assets/translations) or the lib folder for your code you can specify your custom paths : 
+
+| Arguments                    | Short | Default               | Description                                                                 |
+| ---------------------------- | ----- | --------------------- | --------------------------------------------------------------------------- |
+| --translations-dir           | -t    | assets/translations   | Folder containing localization files                                        |
+| --source-dir                 | -s    | lib                   | Folder containing the app code files                                        |
+
 ## 🖨️ Logger
 
 [Easy Localization] logger based on [Easy Logger]

--- a/bin/audit.dart
+++ b/bin/audit.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'audit/audit_command.dart';
 
@@ -8,9 +10,24 @@ void main(List<String> args) {
   parser.addOption('translations-dir', abbr: 't', defaultsTo: 'assets/translations');
   parser.addOption('source-dir', abbr: 's', defaultsTo: 'lib');
 
-  var argResults = parser.parse(actual);
-  AuditCommand().run(
-    transDir: argResults['translations-dir'],
-    srcDir: argResults['source-dir'],
-  );
+  try {
+    var argResults = parser.parse(actual);
+    final transDir = argResults['translations-dir'] as String;
+    final srcDir = argResults['source-dir'] as String;
+
+    if (!Directory(transDir).existsSync()) {
+      stderr.writeln('Error: Translation directory "$transDir" does not exist.');
+      exit(1);
+    }
+
+    if (!Directory(srcDir).existsSync()) {
+      stderr.writeln('Error: Source directory "$srcDir" does not exist.');
+      exit(1);
+    }
+
+    AuditCommand().run(transDir: transDir, srcDir: srcDir);
+  } catch (e) {
+    stderr.writeln('Error: $e');
+    exit(1);
+  }
 }

--- a/bin/audit.dart
+++ b/bin/audit.dart
@@ -1,0 +1,16 @@
+import 'package:args/args.dart';
+import 'audit/audit_command.dart';
+
+void main(List<String> args) {
+  final actual = args.isEmpty ? ['audit'] : args;
+  var parser = ArgParser();
+
+  parser.addOption('translations-dir', abbr: 't', defaultsTo: 'assets/translations');
+  parser.addOption('source-dir', abbr: 's', defaultsTo: 'lib');
+
+  var argResults = parser.parse(actual);
+  AuditCommand().run(
+    transDir: argResults['translations-dir'],
+    srcDir: argResults['source-dir'],
+  );
+}

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart';
+
+class AuditCommand {
+  void run({required String transDir, required String srcDir}) {
+    final allTranslations = _loadTranslations(Directory(transDir));
+    final usedKeys = _scanSourceForKeys(Directory(srcDir));
+
+    _report(allTranslations, usedKeys);
+  }
+
+  /// Walks [translationsDir], reads every `.json`, flattens nested maps
+  /// into dot‑separated keys, and returns a map:
+  ///   { 'en': {'home.title', 'home.subtitle', …}, 'fr': { … } }
+  Map<String, Set<String>> _loadTranslations(Directory translationsDir) {
+    final result = <String, Set<String>>{};
+    for (var file in translationsDir.listSync().whereType<File>()) {
+      if (!file.path.endsWith('.json')) continue;
+      final langCode = basenameWithoutExtension(file.path);
+      final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+      result[langCode] = _flatten(jsonMap);
+    }
+    return result;
+  }
+
+  Set<String> _flatten(Map<String, dynamic> json, [String parentKey = '']) {
+    final keys = <String>{};
+    for (var entry in json.entries) {
+      final key = entry.key;
+      final value = entry.value;
+
+      final newKey = parentKey.isEmpty ? key : '$parentKey.$key';
+      if (value is String) {
+        keys.add(newKey);
+        continue;
+      }
+
+      if (value is Map<String, dynamic>) {
+        keys.addAll(_flatten(value, newKey));
+      }
+    }
+    return keys;
+  }
+
+  Set<String> _scanSourceForKeys(Directory srcDir) {
+    List<RegExp> keyPatterns = [
+      // 1) tr('foo.bar') or tr("foo.bar"), with optional args/comma before the )
+      RegExp(r"""\btr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
+
+      // 2) context.tr('foo.bar') same as above but with the context qualifier
+      RegExp(r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
+
+      // 3) 'foo.bar'.tr() or "foo.bar".tr(), allowing whitespace/newlines
+      RegExp(r"""['"]([^'"]+)['"]\s*\.\s*tr\s*\(\s*[^)]*\)"""),
+
+      // 4) generated keys: LocaleKeys.foo_bar (whitespace around the dot ok)
+      RegExp(r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
+    ];
+
+    final used = <String>{};
+
+    for (var file in srcDir.listSync(recursive: true).whereType<File>().where((f) => f.path.endsWith('.dart'))) {
+      final content = file.readAsStringSync();
+      for (var pattern in keyPatterns) {
+        final matches = pattern.allMatches(content);
+        for (var match in matches) {
+          if (match.groupCount > 0) {
+            used.add(match.group(1)!);
+          }
+        }
+      }
+    }
+
+    return used;
+  }
+
+  void _report(Map<String, Set<String>> allTranslations, Set<String> usedKeys) {
+    stderr.writeln('=== Keys Audit ===');
+
+    for (var lang in allTranslations.keys) {
+      final keysInFile = allTranslations[lang]!;
+      final missing = usedKeys.difference(keysInFile);
+      final missingWithVariables = missing.where((key) => key.contains('\$')).toList();
+      final missingWithoutVariables = missing.where((key) => !key.contains('\$')).toList();
+
+      stderr.writeln('\nLanguage: $lang');
+      if (missingWithVariables.isEmpty && missingWithoutVariables.isEmpty) {
+        stderr.writeln('  ✅ all good!');
+      }
+
+      if (missingWithoutVariables.isNotEmpty) {
+        stderr.writeln('  🔴 Missing (${missingWithoutVariables.length}):');
+        for (var key in missingWithoutVariables) {
+          stderr.writeln('    – $key');
+        }
+
+        stderr.writeln('\n');
+      }
+
+      if (missingWithVariables.isNotEmpty) {
+        stderr.writeln('  🟡 Missing with variables (${missingWithVariables.length}):');
+        stderr.writeln('    These keys may not be missing as they contain variables that cannot be verified.');
+        for (var key in missingWithVariables) {
+          stderr.writeln('    – $key');
+        }
+      }
+    }
+  }
+}

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -5,10 +5,27 @@ import 'package:path/path.dart';
 
 class AuditCommand {
   void run({required String transDir, required String srcDir}) {
-    final allTranslations = _loadTranslations(Directory(transDir));
-    final usedKeys = _scanSourceForKeys(Directory(srcDir));
+    try {
+      final translationDir = Directory(transDir);
+      final sourceDir = Directory(srcDir);
 
-    _report(allTranslations, usedKeys);
+      if (!translationDir.existsSync()) {
+        stderr.writeln('Error: Translation directory "$transDir" does not exist.');
+        exit(1);
+      }
+
+      if (!sourceDir.existsSync()) {
+        stderr.writeln('Error: Source directory "$srcDir" does not exist.');
+        exit(1);
+      }
+
+      final allTranslations = _loadTranslations(translationDir);
+      final usedKeys = _scanSourceForKeys(sourceDir);
+
+      _report(allTranslations, usedKeys);
+    } catch (e) {
+      stderr.writeln('Error during audit: $e');
+    }
   }
 
   /// Walks [translationsDir], reads every `.json`, flattens nested maps
@@ -18,9 +35,14 @@ class AuditCommand {
     final result = <String, Set<String>>{};
     for (var file in translationsDir.listSync().whereType<File>()) {
       if (!file.path.endsWith('.json')) continue;
-      final langCode = basenameWithoutExtension(file.path);
-      final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
-      result[langCode] = _flatten(jsonMap);
+
+      try {
+        final langCode = basenameWithoutExtension(file.path);
+        final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+        result[langCode] = _flatten(jsonMap);
+      } catch (e) {
+        stderr.writeln('Error reading ${file.path}: $e');
+      }
     }
     return result;
   }
@@ -39,6 +61,11 @@ class AuditCommand {
 
       if (value is Map<String, dynamic>) {
         keys.addAll(_flatten(value, newKey));
+        continue;
+      }
+
+      if (value is List || value is num || value is bool) {
+        keys.add(newKey);
       }
     }
     return keys;
@@ -57,19 +84,29 @@ class AuditCommand {
 
       // 4) generated keys: LocaleKeys.foo_bar (whitespace around the dot ok)
       RegExp(r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
+
+      // 5) plural() calls
+      RegExp(r"""\bplural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
+
+      // 6) context.plural() calls
+      RegExp(r"""context\s*\.\s*plural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
     ];
 
     final used = <String>{};
 
     for (var file in srcDir.listSync(recursive: true).whereType<File>().where((f) => f.path.endsWith('.dart'))) {
-      final content = file.readAsStringSync();
-      for (var pattern in keyPatterns) {
-        final matches = pattern.allMatches(content);
-        for (var match in matches) {
-          if (match.groupCount > 0) {
-            used.add(match.group(1)!);
+      try {
+        final content = file.readAsStringSync();
+        for (var pattern in keyPatterns) {
+          final matches = pattern.allMatches(content);
+          for (var match in matches) {
+            if (match.groupCount > 0) {
+              used.add(match.group(1)!);
+            }
           }
         }
+      } catch (e) {
+        stderr.writeln('Error reading ${file.path}: $e');
       }
     }
 

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -11,12 +11,12 @@ class AuditCommand {
 
       if (!translationDir.existsSync()) {
         stderr.writeln('Error: Translation directory "$transDir" does not exist.');
-        exit(1);
+        return;
       }
 
       if (!sourceDir.existsSync()) {
         stderr.writeln('Error: Source directory "$srcDir" does not exist.');
-        exit(1);
+        return;
       }
 
       final allTranslations = _loadTranslations(translationDir);
@@ -101,7 +101,11 @@ class AuditCommand {
           final matches = pattern.allMatches(content);
           for (var match in matches) {
             if (match.groupCount > 0) {
-              used.add(match.group(1)!);
+              String key = match.group(1)!;
+              if (pattern.pattern.contains('LocaleKeys')) {
+                key = key.replaceAll('_', '.');
+              }
+              used.add(key);
             }
           }
         }


### PR DESCRIPTION
An alternative to key generation by comparing all the keys in code to the one in the localization files and return the one not present.

_flutter pub run easy_localization:audit_

**Arguments :**
 --translations-dir         | -t    | assets/translations   | Folder containing localization files                                       
 --source-dir                 | -s    | lib                               | Folder containing the app code files                                               

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line audit tool to identify translation keys used in the app but missing from translation files.
  * Added support for customizing the translations and source code directories when running the audit.

* **Documentation**
  * Updated the README with instructions and details on using the new audit feature, including command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->