### PR TITLE
[Feature] Linked Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,8 +411,6 @@ print('example.emptyNameError'.tr()); //Output: Please fill in your full name
 
 ### 🔥 Linked files:
 
-> ⚠ This is only available for the default asset loader (on Json Files).
-
 You can split translations for a single locale into multiple files by using linked files. This helps keep your JSON clean and maintainable.
 
 To link an external file, set the key’s value to a path prefixed with `:/`, relative to your translations directory. For example, with default path `assets/translations` and locale `en-US`:
@@ -435,7 +433,7 @@ assets
         └── notifications.json  
 ```
 
-Each linked file must contain a valid JSON object of translation keys.  
+Each linked file must contain a valid object of translation keys (of the file type you are using [Other file types](#-loading-translations-from-other-resources)).  
 
 Don't forget to add your linked files (or linked files folder, here assets/translations/en-US/), to your pubspec.yaml : [See installation](#-installation).
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ flutter:
     - assets/translations/
 ```
 
+
+
 ### 🔌 Loading translations from other resources
 
 You can use JSON,CSV,HTTP,XML,Yaml files, etc.
@@ -406,6 +408,36 @@ Output:
 ```dart
 print('example.emptyNameError'.tr()); //Output: Please fill in your full name
 ```
+
+### 🔥 Linked files:
+
+> ⚠ This is only available for the default asset loader (on Json Files).
+
+You can split translations for a single locale into multiple files by using linked files. This helps keep your JSON clean and maintainable.
+
+To link an external file, set the key’s value to a path prefixed with `:/`, relative to your translations directory. For example, with default path `assets/translations` and locale `en-US`:
+
+```json
+{
+  "errors": ":/errors.json",
+  "validation": ":/validation.json",
+  "notifications": ":/notifications.json"
+}
+```
+
+At runtime, Easy Localization will load:
+```
+assets
+└── translations
+    └── en-US
+        ├── errors.json 
+        ├── validation.json  
+        └── notifications.json  
+```
+
+Each linked file must contain a valid JSON object of translation keys.  
+
+Don't forget to add your linked files (or linked files folder, here assets/translations/en-US/), to your pubspec.yaml : [See installation](#-installation).
 
 ### 🔥 Reset locale `resetLocale()`
 

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'dart:io';
-
+import 'package:easy_localization/src/linked_file_resolver.dart';
 import 'package:path/path.dart';
+import '../../lib/src/file_loaders/io_file_loader.dart';
 
 class AuditCommand {
-  void run({required String transDir, required String srcDir}) {
+  void run({required String transDir, required String srcDir}) async {
     try {
       final translationDir = Directory(transDir);
       final sourceDir = Directory(srcDir);
@@ -19,7 +20,7 @@ class AuditCommand {
         return;
       }
 
-      final allTranslations = _loadTranslations(translationDir);
+      final allTranslations = await _loadTranslations(translationDir);
       final usedKeys = _scanSourceForKeys(sourceDir);
 
       _report(allTranslations, usedKeys);
@@ -31,15 +32,30 @@ class AuditCommand {
   /// Walks [translationsDir], reads every `.json`, flattens nested maps
   /// into dot‑separated keys, and returns a map:
   ///   { 'en': {'home.title', 'home.subtitle', …}, 'fr': { … } }
-  Map<String, Set<String>> _loadTranslations(Directory translationsDir) {
+  /// Also handles linked translation files (those containing ':/file.json' references)
+  Future<Map<String, Set<String>>> _loadTranslations(Directory translationsDir) async {
     final result = <String, Set<String>>{};
+    const IOFileLoader fileLoader = IOFileLoader();
+    const LinkedFileResolver linkedFileResolver = JsonLinkedFileResolver(fileLoader: fileLoader);
+
     for (var file in translationsDir.listSync().whereType<File>()) {
       if (!file.path.endsWith('.json')) continue;
 
       try {
-        final langCode = basenameWithoutExtension(file.path);
+        final local = basenameWithoutExtension(file.path);
+        final langCode = local.split('-').first;
+        final hasCountryCode = local.split('-').length > 1;
+        final countryCode = hasCountryCode ? local.split('-').last : null;
         final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
-        result[langCode] = _flatten(jsonMap);
+
+        // Process linked files if present using the shared resolver
+        final resolvedJson = await linkedFileResolver.resolveLinkedFiles(
+          basePath: translationsDir.path,
+          languageCode: langCode,
+          baseJson: jsonMap,
+          countryCode: countryCode,
+        );
+        result[local] = _flatten(resolvedJson);
       } catch (e) {
         stderr.writeln('Error reading ${file.path}: $e');
       }

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart';
 import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
 
 class AuditCommand {
-  void run({required String transDir, required String srcDir}) async {
+  Future<void> run({required String transDir, required String srcDir}) async {
     try {
       final translationDir = Directory(transDir);
       final sourceDir = Directory(srcDir);

--- a/example/lib/generated/codegen_loader.g.dart
+++ b/example/lib/generated/codegen_loader.g.dart
@@ -4,10 +4,11 @@
 
 import 'dart:ui';
 
-import 'package:easy_localization/easy_localization.dart' show AssetLoader;
+import 'package:easy_localization/easy_localization.dart'
+    show AssetLoader, JsonLinkedFileResolver, RootBundleFileLoader;
 
 class CodegenLoader extends AssetLoader {
-  const CodegenLoader();
+  const CodegenLoader() : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
@@ -20,11 +21,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} مكتوبة باللغة {lang}",
     "clickMe": "إضغط هنا",
     "profile": {
-      "reset_password": {
-        "label": "اعادة تعين كلمة السر",
-        "username": "المستخدم",
-        "password": "كلمة السر"
-      }
+      "reset_password": {"label": "اعادة تعين كلمة السر", "username": "المستخدم", "password": "كلمة السر"}
     },
     "clicked": {
       "zero": "لم تنقر بعد!",
@@ -55,11 +52,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} مكتوبة باللغة {lang}",
     "clickMe": "إضغط هنا",
     "profile": {
-      "reset_password": {
-        "label": "اعادة تعين كلمة السر",
-        "username": "المستخدم",
-        "password": "كلمة السر"
-      }
+      "reset_password": {"label": "اعادة تعين كلمة السر", "username": "المستخدم", "password": "كلمة السر"}
     },
     "clicked": {
       "zero": "لم تنقر بعد!",
@@ -90,11 +83,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} ist in {lang} geschrieben",
     "clickMe": "Click mich",
     "profile": {
-      "reset_password": {
-        "label": "Password zurücksetzten",
-        "username": "Name",
-        "password": "Password"
-      }
+      "reset_password": {"label": "Password zurücksetzten", "username": "Name", "password": "Password"}
     },
     "clicked": {
       "zero": "Du hast {} mal geklickt",
@@ -125,11 +114,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} ist in {lang} geschrieben",
     "clickMe": "Click mich",
     "profile": {
-      "reset_password": {
-        "label": "Password zurücksetzten",
-        "username": "Name",
-        "password": "Password"
-      }
+      "reset_password": {"label": "Password zurücksetzten", "username": "Name", "password": "Password"}
     },
     "clicked": {
       "zero": "Du hast {} mal geklickt",
@@ -160,11 +145,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} are written in the {lang} language",
     "clickMe": "Click me",
     "profile": {
-      "reset_password": {
-        "label": "Reset Password",
-        "username": "Username",
-        "password": "password"
-      }
+      "reset_password": {"label": "Reset Password", "username": "Username", "password": "password"}
     },
     "clicked": {
       "zero": "You clicked {} times!",
@@ -195,11 +176,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} are written in the {lang} language",
     "clickMe": "Click me",
     "profile": {
-      "reset_password": {
-        "label": "Reset Password",
-        "username": "Username",
-        "password": "password"
-      }
+      "reset_password": {"label": "Reset Password", "username": "Username", "password": "password"}
     },
     "clicked": {
       "zero": "You clicked {} times!",
@@ -230,11 +207,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} написан на языке {lang}",
     "clickMe": "Нажми на меня",
     "profile": {
-      "reset_password": {
-        "label": "Сбросить пароль",
-        "username": "Логин",
-        "password": "Пароль"
-      }
+      "reset_password": {"label": "Сбросить пароль", "username": "Логин", "password": "Пароль"}
     },
     "clicked": {
       "zero": "Ты кликнул {} раз!",
@@ -255,10 +228,7 @@ class CodegenLoader extends AssetLoader {
     "gender": {
       "male": "Привет мужык ;) ",
       "female": "Привет девчуля :)",
-      "with_arg": {
-        "male": "Привет мужык ;) {}",
-        "female": "Привет девчуля :) {}"
-      }
+      "with_arg": {"male": "Привет мужык ;) {}", "female": "Привет девчуля :) {}"}
     },
     "reset_locale": "Сбросить язык"
   };
@@ -268,11 +238,7 @@ class CodegenLoader extends AssetLoader {
     "msg_named": "{} написан на языке {lang}",
     "clickMe": "Нажми на меня",
     "profile": {
-      "reset_password": {
-        "label": "Сбросить пароль",
-        "username": "Логин",
-        "password": "Пароль"
-      }
+      "reset_password": {"label": "Сбросить пароль", "username": "Логин", "password": "Пароль"}
     },
     "clicked": {
       "zero": "Ты кликнул {} раз!",
@@ -293,10 +259,7 @@ class CodegenLoader extends AssetLoader {
     "gender": {
       "male": "Привет мужык ;) ",
       "female": "Привет девчуля :)",
-      "with_arg": {
-        "male": "Привет мужык ;) {}",
-        "female": "Привет девчуля :) {}"
-      }
+      "with_arg": {"male": "Привет мужык ;) {}", "female": "Привет девчуля :) {}"}
     },
     "reset_locale": "Сбросить язык"
   };

--- a/example/lib/generated/codegen_loader.g.dart
+++ b/example/lib/generated/codegen_loader.g.dart
@@ -8,7 +8,10 @@ import 'package:easy_localization/easy_localization.dart'
     show AssetLoader, JsonLinkedFileResolver, RootBundleFileLoader;
 
 class CodegenLoader extends AssetLoader {
-  const CodegenLoader() : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+  const CodegenLoader()
+      : super(
+            linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+            fileLoader: const RootBundleFileLoader());
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {

--- a/i18n/en-cyclic.json
+++ b/i18n/en-cyclic.json
@@ -1,0 +1,4 @@
+{
+  "test": "cyclic_test",
+  "cycle_start": ":/cycle_file1.json"
+}

--- a/i18n/en-cyclic/cycle_file1.json
+++ b/i18n/en-cyclic/cycle_file1.json
@@ -1,0 +1,4 @@
+{
+  "file1_value": "This is file 1",
+  "link_to_file2": ":/cycle_file2.json"
+}

--- a/i18n/en-cyclic/cycle_file2.json
+++ b/i18n/en-cyclic/cycle_file2.json
@@ -1,0 +1,4 @@
+{
+  "file2_value": "This is file 2",
+  "link_back_to_file1": ":/cycle_file1.json"
+}

--- a/i18n/en-linked.json
+++ b/i18n/en-linked.json
@@ -1,0 +1,19 @@
+{
+  "test": "test_linked_en",
+  "hello": "Hello",
+  "app": {
+    "name": "Test App",
+    "errors": ":/errors.json"
+  },
+  "validation": ":/validation.json",
+  "nested": {
+    "module": {
+      "messages": ":/nested/messages.json"
+    }
+  },
+  "multiple": {
+    "errors": ":/multi_errors.json",
+    "validation": ":/multi_validation.json"
+  },
+  "deep_nested": ":/deep/level1.json"
+}

--- a/i18n/en-linked/deep/level1.json
+++ b/i18n/en-linked/deep/level1.json
@@ -1,0 +1,4 @@
+{
+  "level1_value": "This is level 1",
+  "level2": ":/deep/level2.json"
+}

--- a/i18n/en-linked/deep/level2.json
+++ b/i18n/en-linked/deep/level2.json
@@ -1,0 +1,4 @@
+{
+  "level2_value": "This is level 2",
+  "final_message": "Deep nesting works!"
+}

--- a/i18n/en-linked/errors.json
+++ b/i18n/en-linked/errors.json
@@ -1,0 +1,5 @@
+{
+  "not_found": "Resource not found",
+  "server_error": "Internal server error",
+  "invalid_input": "Invalid input provided"
+}

--- a/i18n/en-linked/multi_errors.json
+++ b/i18n/en-linked/multi_errors.json
@@ -1,0 +1,5 @@
+{
+  "not_found": "Multiple resource not found",
+  "server_error": "Multiple internal server error",
+  "invalid_input": "Multiple invalid input provided"
+}

--- a/i18n/en-linked/multi_validation.json
+++ b/i18n/en-linked/multi_validation.json
@@ -1,0 +1,6 @@
+{
+  "required": "Multiple field is required",
+  "email": "Multiple valid email address required",
+  "min_length": "Multiple minimum length is {min} characters",
+  "max_length": "Multiple maximum length is {max} characters"
+}

--- a/i18n/en-linked/nested/messages.json
+++ b/i18n/en-linked/nested/messages.json
@@ -1,0 +1,5 @@
+{
+  "welcome": "Welcome to our app",
+  "goodbye": "Thank you for using our app",
+  "info": "This is a nested message file"
+}

--- a/i18n/en-linked/validation.json
+++ b/i18n/en-linked/validation.json
@@ -1,0 +1,6 @@
+{
+  "required": "This field is required",
+  "email": "Please enter a valid email address",
+  "min_length": "Minimum length is {min} characters",
+  "max_length": "Maximum length is {max} characters"
+}

--- a/i18n/en-missing.json
+++ b/i18n/en-missing.json
@@ -1,0 +1,4 @@
+{
+  "test": "missing_file_test",
+  "missing": ":/nonexistent.json"
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,14 +8,7 @@
     "many": "{} many days",
     "other": "{} other days"
   },
-  "hat": {
-    "zero": "no hats",
-    "one": "one hat",
-    "two": "two hats",
-    "few": "few hats",
-    "many": "many hats",
-    "other": "other hats"
-  },
+  "hats": ":/hats.json",
   "hat_other": {
     "other": "other hats"
   }

--- a/i18n/en/hats.json
+++ b/i18n/en/hats.json
@@ -1,0 +1,9 @@
+{
+    "zero": "no hats",
+    "one": "one hat",
+    "two": "two hats",
+    "few": "few hats",
+    "many": "many hats",
+    "other": "other hats"
+
+}

--- a/lib/easy_localization.dart
+++ b/lib/easy_localization.dart
@@ -4,4 +4,6 @@ export 'package:easy_localization/src/easy_localization_app.dart';
 export 'package:easy_localization/src/asset_loader.dart';
 export 'package:easy_localization/src/public.dart';
 export 'package:easy_localization/src/public_ext.dart';
+export 'package:easy_localization/src/linked_file_resolver.dart';
+export 'package:easy_localization/src/file_loaders/root_bundle_file_loader.dart';
 export 'package:intl/intl.dart';

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:developer';
 import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart';
@@ -45,13 +44,15 @@ class RootBundleAssetLoader extends AssetLoader {
 
       if (value is String && value.startsWith(':/')) {
         String filePath = value.substring(2);
-        Map<String, dynamic> linkedJson =
-            json.decode(await rootBundle.loadString(_getLinkedLocalePath(basePath, filePath, locale)));
-        fullJson.addAll({key: linkedJson});
+        value = json.decode(await rootBundle.loadString(_getLinkedLocalePath(basePath, filePath, locale)));
+      }
+
+      if (value is Map<String, dynamic>) {
+        fullJson[key] = await _getLinkedTranslationFileDataFromBaseJson(basePath, locale, value);
         continue;
       }
 
-      fullJson[key] = baseJson[key];
+      fullJson[key] = value;
     }
 
     return fullJson;

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer';
 import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart';
@@ -30,17 +31,23 @@ class RootBundleAssetLoader extends AssetLoader {
     return '$basePath/${locale.toStringWithSeparator(separator: "-")}.json';
   }
 
-  Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(Map<String, dynamic> baseJson) async {
+  String _getLinkedLocalePath(String basePath, String filePath, Locale locale) {
+    return '$basePath/${locale.toStringWithSeparator(separator: "-")}/$filePath';
+  }
+
+  Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(
+      String basePath, Locale locale, Map<String, dynamic> baseJson) async {
     Map<String, dynamic> fullJson = {};
 
     for (var entry in baseJson.entries) {
       var key = entry.key;
       var value = entry.value;
 
-      if (value.startsWith(':/')) {
+      if (value is String && value.startsWith(':/')) {
         String filePath = value.substring(2);
-        baseJson[key] = json.decode(await rootBundle.loadString(filePath));
-        fullJson.addAll(baseJson[key]);
+        Map<String, dynamic> linkedJson =
+            json.decode(await rootBundle.loadString(_getLinkedLocalePath(basePath, filePath, locale)));
+        fullJson.addAll({key: linkedJson});
         continue;
       }
 
@@ -56,6 +63,6 @@ class RootBundleAssetLoader extends AssetLoader {
     EasyLocalization.logger.debug('Load asset from $path');
 
     Map<String, dynamic> baseJson = json.decode(await rootBundle.loadString(localePath));
-    return _getLinkedTranslationFileDataFromBaseJson(baseJson);
+    return _getLinkedTranslationFileDataFromBaseJson(path, locale, baseJson);
   }
 }

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:ui';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/src/file_loaders/file_loader.dart';
 import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
-import 'package:flutter/services.dart';
 
 /// abstract class used to building your Custom AssetLoader
 /// Example:
@@ -17,9 +17,10 @@ import 'package:flutter/services.dart';
 /// ```
 abstract class AssetLoader {
   // Place inside class RootBundleAssetLoader
+  final FileLoader fileLoader;
   final LinkedFileResolver linkedFileResolver;
 
-  const AssetLoader({required this.linkedFileResolver});
+  const AssetLoader({required this.linkedFileResolver, required this.fileLoader});
 
   Future<Map<String, dynamic>?> load(String path, Locale locale);
 }
@@ -28,13 +29,20 @@ abstract class AssetLoader {
 /// default used is RootBundleAssetLoader which uses flutter's assetloader
 ///
 class RootBundleAssetLoader extends AssetLoader {
-  const RootBundleAssetLoader({LinkedFileResolver? linkedFileResolver})
-      : super(
-            linkedFileResolver: linkedFileResolver ?? const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+  const RootBundleAssetLoader({required LinkedFileResolver linkedFileResolver, required FileLoader fileLoader})
+      : super(linkedFileResolver: linkedFileResolver, fileLoader: fileLoader);
+
+  factory RootBundleAssetLoader.fromRootBundle() {
+    return const RootBundleAssetLoader(
+      linkedFileResolver: JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+      fileLoader: RootBundleFileLoader(),
+    );
+  }
 
   factory RootBundleAssetLoader.fromIOFile() {
     return const RootBundleAssetLoader(
       linkedFileResolver: JsonLinkedFileResolver(fileLoader: IOFileLoader()),
+      fileLoader: IOFileLoader(),
     );
   }
 
@@ -47,7 +55,7 @@ class RootBundleAssetLoader extends AssetLoader {
     var localePath = getLocalePath(path, locale);
     EasyLocalization.logger.debug('Load asset from $path');
 
-    Map<String, dynamic> baseJson = json.decode(await linkedFileResolver.fileLoader.loadString(localePath));
+    Map<String, dynamic> baseJson = json.decode(await fileLoader.loadString(localePath));
     return await linkedFileResolver.resolveLinkedFiles(
       basePath: path,
       languageCode: locale.languageCode,

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
 import 'package:flutter/services.dart';
 
 /// abstract class used to building your Custom AssetLoader
@@ -16,7 +16,11 @@ import 'package:flutter/services.dart';
 ///}
 /// ```
 abstract class AssetLoader {
-  const AssetLoader();
+  // Place inside class RootBundleAssetLoader
+  final LinkedFileResolver linkedFileResolver;
+
+  const AssetLoader({required this.linkedFileResolver});
+
   Future<Map<String, dynamic>?> load(String path, Locale locale);
 }
 
@@ -24,76 +28,18 @@ abstract class AssetLoader {
 /// default used is RootBundleAssetLoader which uses flutter's assetloader
 ///
 class RootBundleAssetLoader extends AssetLoader {
-  // Place inside class RootBundleAssetLoader
-  static const int _maxLinkedDepth = 32;
+  const RootBundleAssetLoader({LinkedFileResolver? linkedFileResolver})
+      : super(
+            linkedFileResolver: linkedFileResolver ?? const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
-  const RootBundleAssetLoader();
+  factory RootBundleAssetLoader.fromIOFile() {
+    return const RootBundleAssetLoader(
+      linkedFileResolver: JsonLinkedFileResolver(fileLoader: IOFileLoader()),
+    );
+  }
 
   String getLocalePath(String basePath, Locale locale) {
     return '$basePath/${locale.toStringWithSeparator(separator: "-")}.json';
-  }
-
-  String _getLinkedLocalePath(String basePath, String filePath, Locale locale) {
-    return '$basePath/${locale.toStringWithSeparator(separator: "-")}/$filePath';
-  }
-
-  Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(
-    String basePath,
-    Locale locale,
-    Map<String, dynamic> baseJson, {
-    required Set<String> visited,
-    int depth = 0,
-  }) async {
-    if (depth > _maxLinkedDepth) {
-      throw StateError('Maximum linked files depth ($_maxLinkedDepth) exceeded for $locale at $basePath.');
-    }
-
-    final Map<String, dynamic> fullJson = Map<String, dynamic>.from(baseJson);
-
-    for (final entry in baseJson.entries) {
-      final key = entry.key;
-      var value = entry.value;
-
-      if (value is String && value.startsWith(':/')) {
-        final rawPath = value.substring(2).trim();
-        final linkedAssetPath = _getLinkedLocalePath(basePath, rawPath, locale);
-
-        if (visited.contains(linkedAssetPath)) {
-          throw StateError('Cyclic linked files detected at "$linkedAssetPath" (key: "$key").');
-        }
-
-        final Map<String, dynamic> linkedJson =
-            json.decode(await rootBundle.loadString(linkedAssetPath)) as Map<String, dynamic>;
-
-        visited.add(linkedAssetPath);
-        try {
-          final resolved = await _getLinkedTranslationFileDataFromBaseJson(
-            basePath,
-            locale,
-            linkedJson,
-            visited: visited,
-            depth: depth + 1,
-          );
-          fullJson[key] = resolved;
-        } catch (e) {
-          throw StateError(
-            'Error resolving linked file "$linkedAssetPath" for key "$key": $e',
-          );
-        }
-      }
-
-      if (value is Map<String, dynamic>) {
-        fullJson[key] = await _getLinkedTranslationFileDataFromBaseJson(
-          basePath,
-          locale,
-          value,
-          visited: visited,
-          depth: depth + 1,
-        );
-      }
-    }
-
-    return fullJson;
   }
 
   @override
@@ -101,12 +47,12 @@ class RootBundleAssetLoader extends AssetLoader {
     var localePath = getLocalePath(path, locale);
     EasyLocalization.logger.debug('Load asset from $path');
 
-    Map<String, dynamic> baseJson = json.decode(await rootBundle.loadString(localePath));
-    return await _getLinkedTranslationFileDataFromBaseJson(
-      path,
-      locale,
-      baseJson,
-      visited: <String>{},
+    Map<String, dynamic> baseJson = json.decode(await linkedFileResolver.fileLoader.loadString(localePath));
+    return await linkedFileResolver.resolveLinkedFiles(
+      basePath: path,
+      languageCode: locale.languageCode,
+      countryCode: locale.countryCode,
+      baseJson: baseJson,
     );
   }
 }

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -30,10 +30,32 @@ class RootBundleAssetLoader extends AssetLoader {
     return '$basePath/${locale.toStringWithSeparator(separator: "-")}.json';
   }
 
+  Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(Map<String, dynamic> baseJson) async {
+    Map<String, dynamic> fullJson = {};
+
+    for (var entry in baseJson.entries) {
+      var key = entry.key;
+      var value = entry.value;
+
+      if (value.startsWith(':/')) {
+        String filePath = value.substring(2);
+        baseJson[key] = json.decode(await rootBundle.loadString(filePath));
+        fullJson.addAll(baseJson[key]);
+        continue;
+      }
+
+      fullJson[key] = baseJson[key];
+    }
+
+    return fullJson;
+  }
+
   @override
   Future<Map<String, dynamic>?> load(String path, Locale locale) async {
     var localePath = getLocalePath(path, locale);
     EasyLocalization.logger.debug('Load asset from $path');
-    return json.decode(await rootBundle.loadString(localePath));
+
+    Map<String, dynamic> baseJson = json.decode(await rootBundle.loadString(localePath));
+    return _getLinkedTranslationFileDataFromBaseJson(baseJson);
   }
 }

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -35,7 +35,8 @@ class RootBundleAssetLoader extends AssetLoader {
   }
 
   Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(
-      String basePath, Locale locale, Map<String, dynamic> baseJson) async {
+      String basePath, Locale locale, Map<String, dynamic> baseJson,
+      {List<String> fileLoaded = const []}) async {
     Map<String, dynamic> fullJson = {};
 
     for (var entry in baseJson.entries) {
@@ -44,11 +45,18 @@ class RootBundleAssetLoader extends AssetLoader {
 
       if (value is String && value.startsWith(':/')) {
         String filePath = value.substring(2);
+
+        if (fileLoaded.contains(filePath)) {
+          throw Exception('Circular reference detected: $filePath is loaded multiple times');
+        }
+
+        fileLoaded.add(filePath);
         value = json.decode(await rootBundle.loadString(_getLinkedLocalePath(basePath, filePath, locale)));
       }
 
       if (value is Map<String, dynamic>) {
-        fullJson[key] = await _getLinkedTranslationFileDataFromBaseJson(basePath, locale, value);
+        fullJson[key] =
+            await _getLinkedTranslationFileDataFromBaseJson(basePath, locale, value, fileLoaded: fileLoaded);
         continue;
       }
 

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -37,7 +37,7 @@ class RootBundleAssetLoader extends AssetLoader {
   Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(
       String basePath, Locale locale, Map<String, dynamic> baseJson,
       {List<String> fileLoaded = const []}) async {
-    Map<String, dynamic> fullJson = {};
+    Map<String, dynamic> fullJson = Map<String, dynamic>.from(baseJson);
 
     for (var entry in baseJson.entries) {
       var key = entry.key;
@@ -57,10 +57,7 @@ class RootBundleAssetLoader extends AssetLoader {
       if (value is Map<String, dynamic>) {
         fullJson[key] =
             await _getLinkedTranslationFileDataFromBaseJson(basePath, locale, value, fileLoaded: fileLoaded);
-        continue;
       }
-
-      fullJson[key] = value;
     }
 
     return fullJson;
@@ -72,6 +69,6 @@ class RootBundleAssetLoader extends AssetLoader {
     EasyLocalization.logger.debug('Load asset from $path');
 
     Map<String, dynamic> baseJson = json.decode(await rootBundle.loadString(localePath));
-    return _getLinkedTranslationFileDataFromBaseJson(path, locale, baseJson);
+    return await _getLinkedTranslationFileDataFromBaseJson(path, locale, baseJson);
   }
 }

--- a/lib/src/asset_loader.dart
+++ b/lib/src/asset_loader.dart
@@ -24,6 +24,9 @@ abstract class AssetLoader {
 /// default used is RootBundleAssetLoader which uses flutter's assetloader
 ///
 class RootBundleAssetLoader extends AssetLoader {
+  // Place inside class RootBundleAssetLoader
+  static const int _maxLinkedDepth = 32;
+
   const RootBundleAssetLoader();
 
   String getLocalePath(String basePath, Locale locale) {
@@ -35,28 +38,64 @@ class RootBundleAssetLoader extends AssetLoader {
   }
 
   Future<Map<String, dynamic>> _getLinkedTranslationFileDataFromBaseJson(
-      String basePath, Locale locale, Map<String, dynamic> baseJson,
-      {List<String> fileLoaded = const []}) async {
-    Map<String, dynamic> fullJson = Map<String, dynamic>.from(baseJson);
+    String basePath,
+    Locale locale,
+    Map<String, dynamic> baseJson, {
+    required Set<String> visited,
+    required Map<String, Map<String, dynamic>> cache,
+    int depth = 0,
+  }) async {
+    if (depth > _maxLinkedDepth) {
+      throw StateError('Maximum linked files depth ($_maxLinkedDepth) exceeded for $locale at $basePath.');
+    }
 
-    for (var entry in baseJson.entries) {
-      var key = entry.key;
+    final Map<String, dynamic> fullJson = Map<String, dynamic>.from(baseJson);
+
+    for (final entry in baseJson.entries) {
+      final key = entry.key;
       var value = entry.value;
 
       if (value is String && value.startsWith(':/')) {
-        String filePath = value.substring(2);
+        final rawPath = value.substring(2).trim();
+        // Normalize and reject traversal
+        final normalizedPath = rawPath.replaceAll(RegExp(r'^[\\/]+'), '');
+        if (normalizedPath.contains('..')) {
+          throw FormatException('Invalid linked file path "$rawPath" for key "$key".');
+        }
+        final linkedAssetPath = _getLinkedLocalePath(basePath, normalizedPath, locale);
 
-        if (fileLoaded.contains(filePath)) {
-          throw Exception('Circular reference detected: $filePath is loaded multiple times');
+        if (visited.contains(linkedAssetPath)) {
+          throw StateError('Cyclic linked files detected at "$linkedAssetPath" (key: "$key").');
         }
 
-        fileLoaded.add(filePath);
-        value = json.decode(await rootBundle.loadString(_getLinkedLocalePath(basePath, filePath, locale)));
+        final Map<String, dynamic> linkedJson = cache[linkedAssetPath] ??
+            (cache[linkedAssetPath] =
+                (json.decode(await rootBundle.loadString(linkedAssetPath)) as Map<String, dynamic>));
+
+        visited.add(linkedAssetPath);
+        try {
+          value = await _getLinkedTranslationFileDataFromBaseJson(
+            basePath,
+            locale,
+            linkedJson,
+            visited: visited,
+            cache: cache,
+            depth: depth + 1,
+          );
+        } finally {
+          visited.remove(linkedAssetPath);
+        }
       }
 
       if (value is Map<String, dynamic>) {
-        fullJson[key] =
-            await _getLinkedTranslationFileDataFromBaseJson(basePath, locale, value, fileLoaded: fileLoaded);
+        fullJson[key] = await _getLinkedTranslationFileDataFromBaseJson(
+          basePath,
+          locale,
+          value,
+          visited: visited,
+          cache: cache,
+          depth: depth + 1,
+        );
       }
     }
 
@@ -69,6 +108,12 @@ class RootBundleAssetLoader extends AssetLoader {
     EasyLocalization.logger.debug('Load asset from $path');
 
     Map<String, dynamic> baseJson = json.decode(await rootBundle.loadString(localePath));
-    return await _getLinkedTranslationFileDataFromBaseJson(path, locale, baseJson);
+    return await _getLinkedTranslationFileDataFromBaseJson(
+      path,
+      locale,
+      baseJson,
+      visited: <String>{},
+      cache: <String, Map<String, dynamic>>{},
+    );
   }
 }

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -152,14 +152,12 @@ class EasyLocalization extends StatefulWidget {
   _EasyLocalizationState createState() => _EasyLocalizationState();
 
   // ignore: library_private_types_in_public_api
-  static _EasyLocalizationProvider? of(BuildContext context) =>
-      _EasyLocalizationProvider.of(context);
+  static _EasyLocalizationProvider? of(BuildContext context) => _EasyLocalizationProvider.of(context);
 
   /// ensureInitialized needs to be called in main
   /// so that savedLocale is loaded and used from the
   /// start.
-  static Future<void> ensureInitialized() async =>
-      await EasyLocalizationController.initEasyLocation();
+  static Future<void> ensureInitialized() async => await EasyLocalizationController.initEasyLocation();
 
   /// Customizable logger
   static EasyLogger logger = EasyLogger(name: '🌎 Easy Localization');
@@ -216,8 +214,7 @@ class _EasyLocalizationState extends State<EasyLocalization> {
       delegate: _EasyLocalizationDelegate(
         localizationController: localizationController,
         supportedLocales: widget.supportedLocales,
-        useFallbackTranslationsForEmptyResources:
-            widget.useFallbackTranslationsForEmptyResources,
+        useFallbackTranslationsForEmptyResources: widget.useFallbackTranslationsForEmptyResources,
         ignorePluralRules: widget.ignorePluralRules,
       ),
     );
@@ -253,8 +250,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   // _EasyLocalizationDelegate get delegate => parent.delegate;
 
-  _EasyLocalizationProvider(this.parent, this._localeState,
-      {Key? key, required this.delegate})
+  _EasyLocalizationProvider(this.parent, this._localeState, {Key? key, required this.delegate})
       : currentLocale = _localeState.locale,
         _translationsLoaded = _localeState.translations != null,
         super(key: key, child: parent.child) {
@@ -292,8 +288,7 @@ class _EasyLocalizationProvider extends InheritedWidget {
 
   @override
   bool updateShouldNotify(_EasyLocalizationProvider oldWidget) {
-    return oldWidget.currentLocale != locale
-        || oldWidget._translationsLoaded != _translationsLoaded;
+    return oldWidget.currentLocale != locale || oldWidget._translationsLoaded != _translationsLoaded;
   }
 
   static _EasyLocalizationProvider? of(BuildContext context) =>
@@ -332,8 +327,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
       value,
       translations: localizationController!.translations,
       fallbackTranslations: localizationController!.fallbackTranslations,
-      useFallbackTranslationsForEmptyResources:
-          useFallbackTranslationsForEmptyResources,
+      useFallbackTranslationsForEmptyResources: useFallbackTranslationsForEmptyResources,
       ignorePluralRules: ignorePluralRules,
     );
     return Future.value(Localization.instance);

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -137,7 +137,10 @@ class EasyLocalization extends StatefulWidget {
     this.useFallbackTranslations = false,
     this.useFallbackTranslationsForEmptyResources = false,
     this.ignorePluralRules = true,
-    this.assetLoader = const RootBundleAssetLoader(),
+    this.assetLoader = const RootBundleAssetLoader(
+      fileLoader: RootBundleFileLoader(),
+      linkedFileResolver: JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+    ),
     this.extraAssetLoaders,
     this.saveLocale = true,
     this.errorWidget,

--- a/lib/src/file_loaders/file_loader.dart
+++ b/lib/src/file_loaders/file_loader.dart
@@ -1,0 +1,5 @@
+/// Abstract file loader interface to allow different implementations
+/// for Flutter runtime (using rootBundle) and CLI (using dart:io)
+abstract class FileLoader {
+  Future<String> loadString(String path);
+}

--- a/lib/src/file_loaders/io_file_loader.dart
+++ b/lib/src/file_loaders/io_file_loader.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:easy_localization/src/file_loaders/file_loader.dart';
+
+/// File loader implementation for Dart CLI applications using dart:io
+class IOFileLoader implements FileLoader {
+  const IOFileLoader();
+
+  @override
+  Future<String> loadString(String path) async {
+    final file = File(path);
+    if (!file.existsSync()) {
+      throw FileSystemException('File not found', path);
+    }
+    return file.readAsString();
+  }
+}

--- a/lib/src/file_loaders/root_bundle_file_loader.dart
+++ b/lib/src/file_loaders/root_bundle_file_loader.dart
@@ -1,0 +1,12 @@
+import 'package:easy_localization/src/file_loaders/file_loader.dart';
+import 'package:flutter/services.dart';
+
+/// File loader implementation for Flutter applications using rootBundle
+class RootBundleFileLoader implements FileLoader {
+  const RootBundleFileLoader();
+
+  @override
+  Future<String> loadString(String path) async {
+    return rootBundle.loadString(path);
+  }
+}

--- a/lib/src/linked_file_resolver.dart
+++ b/lib/src/linked_file_resolver.dart
@@ -87,7 +87,7 @@ class JsonLinkedFileResolver extends LinkedFileResolver {
           languageCode: languageCode,
           baseJson: value,
           visited: visited,
-          depth: depth + 1,
+          depth: depth,
           countryCode: countryCode,
         );
       }

--- a/lib/src/linked_file_resolver.dart
+++ b/lib/src/linked_file_resolver.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:easy_localization/src/file_loaders/file_loader.dart';
+
+/// Resolves linked translation files by loading referenced files and merging them
+/// into the base JSON structure. Handles the ':/filename.json' syntax used in linked files.
+
+abstract class LinkedFileResolver {
+  final int maxLinkedDepth = 32;
+  final FileLoader fileLoader;
+
+  const LinkedFileResolver({required this.fileLoader});
+
+  Future<Map<String, dynamic>> resolveLinkedFiles({
+    required String basePath,
+    required String languageCode,
+    required Map<String, dynamic> baseJson,
+    Set<String>? visited,
+    int depth = 0,
+    String? countryCode,
+  });
+
+  String getLinkedLocalePath(String basePath, String filePath, String languageCode, {String? countryCode}) {
+    if (countryCode != null) {
+      return '$basePath/$languageCode-$countryCode/$filePath';
+    }
+
+    return '$basePath/$languageCode/$filePath';
+  }
+}
+
+class JsonLinkedFileResolver extends LinkedFileResolver {
+  const JsonLinkedFileResolver({required FileLoader fileLoader}) : super(fileLoader: fileLoader);
+
+  @override
+  Future<Map<String, dynamic>> resolveLinkedFiles({
+    required String basePath,
+    required String languageCode,
+    required Map<String, dynamic> baseJson,
+    Set<String>? visited,
+    int depth = 0,
+    String? countryCode,
+  }) async {
+    visited ??= <String>{};
+
+    if (depth > maxLinkedDepth) {
+      throw StateError('Maximum linked files depth ($maxLinkedDepth) exceeded for $languageCode at $basePath.');
+    }
+
+    final Map<String, dynamic> fullJson = Map<String, dynamic>.from(baseJson);
+
+    for (final entry in baseJson.entries) {
+      final key = entry.key;
+      var value = entry.value;
+
+      if (value is String && value.startsWith(':/')) {
+        final rawPath = value.substring(2).trim();
+        final linkedAssetPath = getLinkedLocalePath(basePath, rawPath, languageCode, countryCode: countryCode);
+
+        if (visited.contains(linkedAssetPath)) {
+          throw StateError('Cyclic linked files detected at "$linkedAssetPath" (key: "$key").');
+        }
+
+        try {
+          final linkedContent = await fileLoader.loadString(linkedAssetPath);
+          final Map<String, dynamic> linkedJson = json.decode(linkedContent) as Map<String, dynamic>;
+
+          visited.add(linkedAssetPath);
+
+          final resolved = await resolveLinkedFiles(
+            basePath: basePath,
+            languageCode: languageCode,
+            baseJson: linkedJson,
+            visited: visited,
+            depth: depth + 1,
+            countryCode: countryCode,
+          );
+          fullJson[key] = resolved;
+        } catch (e) {
+          throw StateError(
+            'Error resolving linked file "$linkedAssetPath" for key "$key": $e',
+          );
+        }
+      } else if (value is Map<String, dynamic>) {
+        fullJson[key] = await resolveLinkedFiles(
+          basePath: basePath,
+          languageCode: languageCode,
+          baseJson: value,
+          visited: visited,
+          depth: depth + 1,
+          countryCode: countryCode,
+        );
+      }
+    }
+
+    return fullJson;
+  }
+}

--- a/test/asset_loader_linked_files_test.dart
+++ b/test/asset_loader_linked_files_test.dart
@@ -1,0 +1,219 @@
+import 'dart:developer';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:easy_localization/src/easy_localization_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() async {
+  // Initialize the test environment
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+  await EasyLocalization.ensureInitialized();
+
+  group('Asset Loader - Linked Translation Files', () {
+    group('RootBundleAssetLoader with linked files', () {
+      test('should load single linked file', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'linked'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'linked')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en', 'linked'));
+
+        expect(result['hello'], 'Hello');
+        expect(result['app']['name'], 'Test App');
+        expect(result['app']['errors']['not_found'], 'Resource not found');
+        expect(result['app']['errors']['server_error'], 'Internal server error');
+        expect(result['app']['errors']['invalid_input'], 'Invalid input provided');
+      });
+
+      test('should load multiple linked files', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'linked'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'linked')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en', 'linked'));
+
+        // Check validation linked file
+        expect(result['validation']['required'], 'This field is required');
+        expect(result['validation']['email'], 'Please enter a valid email address');
+        expect(result['validation']['min_length'], 'Minimum length is {min} characters');
+
+        // Check multiple references to same file work
+        expect(result['multiple']['errors']['not_found'], 'Multiple resource not found');
+        expect(result['multiple']['validation']['required'], 'Multiple field is required');
+      });
+
+      test('should load nested linked files', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'linked'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'linked')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en', 'linked'));
+
+        // Check nested folder structure
+        expect(result['nested']['module']['messages']['welcome'], 'Welcome to our app');
+        expect(result['nested']['module']['messages']['goodbye'], 'Thank you for using our app');
+        expect(result['nested']['module']['messages']['info'], 'This is a nested message file');
+      });
+
+      test('should load deeply nested linked files', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'linked'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'linked')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en', 'linked'));
+
+        // Check deep nesting (file linking to another file)
+        expect(result['deep_nested']['level1_value'], 'This is level 1');
+        expect(result['deep_nested']['level2']['level2_value'], 'This is level 2');
+        expect(result['deep_nested']['level2']['final_message'], 'Deep nesting works!');
+      });
+
+      test('should preserve original structure with linked files', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'linked'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'linked')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en', 'linked'));
+
+        // Verify that the original structure is preserved
+        expect(result['test'], 'test_linked_en');
+        expect(result['hello'], 'Hello');
+        expect(result.containsKey('app'), true);
+        expect(result['app'].containsKey('name'), true);
+        expect(result['app'].containsKey('errors'), true);
+
+        // The linked reference should be replaced with actual content
+        expect(result['app']['errors'] is Map, true);
+        expect(result['app']['errors'] is String, false);
+      });
+    });
+
+    group('Error handling for linked files', () {
+      test('should throw error for cyclic linked files', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'cyclic'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'cyclic')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            // Don't just log, rethrow the error so we can catch it in tests
+            throw e;
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        try {
+          await controller.loadTranslations();
+          fail('Expected StateError to be thrown');
+        } catch (e) {
+          expect(e, isA<FlutterError>());
+          expect(e.toString(), contains('Cyclic linked files detected'));
+        }
+      });
+
+      test('should throw error for missing linked file', () async {
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en', 'missing'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en', 'missing')],
+          useOnlyLangCode: false,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            // Don't just log, rethrow the error so we can catch it in tests
+            throw e;
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        try {
+          await controller.loadTranslations();
+          fail('Expected FlutterError to be thrown');
+        } catch (e) {
+          expect(e, isA<FlutterError>());
+        }
+      });
+    });
+
+    group('Edge cases for linked files', () {
+      test('should work with useOnlyLangCode setting', () async {
+        // Test with a simple locale using useOnlyLangCode
+        final controller = EasyLocalizationController(
+          forceLocale: const Locale('en'),
+          path: '../../i18n',
+          supportedLocales: const [Locale('en')],
+          useOnlyLangCode: true,
+          useFallbackTranslations: false,
+          saveLocale: false,
+          onLoadError: (FlutterError e) {
+            log(e.toString());
+          },
+          assetLoader: const RootBundleAssetLoader(),
+        );
+
+        await controller.loadTranslations();
+        final result = await controller.loadTranslationData(const Locale('en'));
+
+        // Should successfully load the en.json file
+        expect(result['test'], 'test_en');
+        expect(result.containsKey('hats'), true);
+        expect((result['hats'] as Map<String, dynamic>).containsKey('zero'), true);
+      });
+    });
+  });
+}

--- a/test/asset_loader_linked_files_test.dart
+++ b/test/asset_loader_linked_files_test.dart
@@ -17,7 +17,7 @@ void main() async {
       test('should load single linked file', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'linked'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'linked')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -25,7 +25,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();
@@ -41,7 +41,7 @@ void main() async {
       test('should load multiple linked files', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'linked'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'linked')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -49,7 +49,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();
@@ -68,7 +68,7 @@ void main() async {
       test('should load nested linked files', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'linked'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'linked')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -76,7 +76,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();
@@ -91,7 +91,7 @@ void main() async {
       test('should load deeply nested linked files', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'linked'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'linked')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -99,7 +99,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();
@@ -114,7 +114,7 @@ void main() async {
       test('should preserve original structure with linked files', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'linked'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'linked')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -122,7 +122,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();
@@ -145,7 +145,7 @@ void main() async {
       test('should throw error for cyclic linked files', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'cyclic'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'cyclic')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -154,7 +154,7 @@ void main() async {
             // Don't just log, rethrow the error so we can catch it in tests
             throw e;
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         try {
@@ -169,7 +169,7 @@ void main() async {
       test('should throw error for missing linked file', () async {
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en', 'missing'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en', 'missing')],
           useOnlyLangCode: false,
           useFallbackTranslations: false,
@@ -178,7 +178,7 @@ void main() async {
             // Don't just log, rethrow the error so we can catch it in tests
             throw e;
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         try {
@@ -195,7 +195,7 @@ void main() async {
         // Test with a simple locale using useOnlyLangCode
         final controller = EasyLocalizationController(
           forceLocale: const Locale('en'),
-          path: '../../i18n',
+          path: 'i18n',
           supportedLocales: const [Locale('en')],
           useOnlyLangCode: true,
           useFallbackTranslations: false,
@@ -203,7 +203,7 @@ void main() async {
           onLoadError: (FlutterError e) {
             log(e.toString());
           },
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
         );
 
         await controller.loadTranslations();

--- a/test/easy_localization_context_test.dart
+++ b/test/easy_localization_context_test.dart
@@ -87,9 +87,7 @@ void main() async {
             saveLocale: false,
             useOnlyLangCode: true,
             // fallbackLocale:Locale('en') ,
-            supportedLocales: const [
-              Locale('ar')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('ar')], // Locale('en', 'US'), Locale('ar','DZ')
             child: const MyApp(),
           ));
           // await tester.idle();
@@ -117,10 +115,7 @@ void main() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
               // fallbackLocale:Locale('en') ,
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             // await tester.idle();
@@ -140,13 +135,10 @@ void main() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
               // fallbackLocale:Locale('en') ,
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
-            // await tester.idle();
+            await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
             await tester.pump();
 
@@ -161,13 +153,10 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
-            // await tester.idle();
+            await tester.idle();
             // The async delegator load will require build on the next frame. Thus, pump
             await tester.pump();
 
@@ -182,10 +171,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: const Locale('ar', 'DZ'),
               child: const MyApp(),
             ));
@@ -208,10 +194,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               child: const MyApp(),
             ));
             await tester.idle();
@@ -229,10 +212,7 @@ void main() async {
           await tester.runAsync(() async {
             await tester.pumpWidget(EasyLocalization(
               path: '../../i18n',
-              supportedLocales: const [
-                Locale('en', 'US'),
-                Locale('ar', 'DZ')
-              ], // Locale('en', 'US'), Locale('ar','DZ')
+              supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
               startLocale: const Locale('ar', 'DZ'),
               child: const MyApp(),
             ));

--- a/test/easy_localization_extra_asset_loaders_test.dart
+++ b/test/easy_localization_extra_asset_loaders_test.dart
@@ -29,8 +29,7 @@ void main() {
       expect(result.entries.length, 1);
     });
 
-    test('load assets from external loader and merge with asset loader',
-        () async {
+    test('load assets from external loader and merge with asset loader', () async {
       final EasyLocalizationController controller = EasyLocalizationController(
         forceLocale: const Locale('en'),
         path: 'path/en.json',
@@ -42,11 +41,10 @@ void main() {
           log(e.toString());
         },
         assetLoader: const ImmutableJsonAssetLoader(),
-        extraAssetLoaders: [const ExternalAssetLoader()],
+        extraAssetLoaders: [ExternalAssetLoader()],
       );
 
-      final Map<String, dynamic> result =
-          await controller.loadTranslationData(const Locale('en'));
+      final Map<String, dynamic> result = await controller.loadTranslationData(const Locale('en'));
 
       expect(result, {
         'test': 'test',
@@ -57,9 +55,7 @@ void main() {
       expect(result.entries.length, 4);
     });
 
-    test(
-        'load assets from external loader with nested translations and merge with asset loader',
-        () async {
+    test('load assets from external loader with nested translations and merge with asset loader', () async {
       final EasyLocalizationController controller = EasyLocalizationController(
         forceLocale: const Locale('en'),
         path: 'path/en.json',
@@ -71,11 +67,10 @@ void main() {
           log(e.toString());
         },
         assetLoader: const ImmutableJsonAssetLoader(),
-        extraAssetLoaders: [const NestedAssetLoader()],
+        extraAssetLoaders: [NestedAssetLoader()],
       );
 
-      final Map<String, dynamic> result =
-          await controller.loadTranslationData(const Locale('en'));
+      final Map<String, dynamic> result = await controller.loadTranslationData(const Locale('en'));
 
       expect(result, {
         'test': 'test',
@@ -90,9 +85,7 @@ void main() {
       expect(result.entries.length, 2);
     });
 
-    test(
-        'load assets from external loader and merge duplicates with asset loader',
-        () async {
+    test('load assets from external loader and merge duplicates with asset loader', () async {
       final EasyLocalizationController controller = EasyLocalizationController(
         forceLocale: const Locale('en'),
         path: 'path/en.json',
@@ -107,8 +100,7 @@ void main() {
         extraAssetLoaders: [const ImmutableJsonAssetLoader()],
       );
 
-      final Map<String, dynamic> result =
-          await controller.loadTranslationData(const Locale('en'));
+      final Map<String, dynamic> result = await controller.loadTranslationData(const Locale('en'));
 
       expect(result, {'test': 'test'});
       expect(result.entries.length, 1);

--- a/test/easy_localization_test.dart
+++ b/test/easy_localization_test.dart
@@ -57,28 +57,19 @@ void main() {
     });
 
     test('load() succeeds', () async {
-      expect(
-          Localization.load(const Locale('en'), translations: r1.translations),
-          true);
+      expect(Localization.load(const Locale('en'), translations: r1.translations), true);
     });
 
     test('load() with fallback succeeds', () async {
       expect(
-          Localization.load(const Locale('en'),
-              translations: r1.translations,
-              fallbackTranslations: r2.translations),
+          Localization.load(const Locale('en'), translations: r1.translations, fallbackTranslations: r2.translations),
           true);
     });
 
-    test('merge fallbackLocale with locale without country code succeeds',
-        () async {
+    test('merge fallbackLocale with locale without country code succeeds', () async {
       await EasyLocalizationController(
         forceLocale: const Locale('es', 'AR'),
-        supportedLocales: const [
-          Locale('en'),
-          Locale('es'),
-          Locale('es', 'AR')
-        ],
+        supportedLocales: const [Locale('en'), Locale('es'), Locale('es', 'AR')],
         path: 'path/en-us.json',
         useOnlyLangCode: false,
         useFallbackTranslations: true,
@@ -94,12 +85,9 @@ void main() {
     test('localeFromString() succeeds', () async {
       expect(const Locale('ar'), 'ar'.toLocale());
       expect(const Locale('ar', 'DZ'), 'ar_DZ'.toLocale());
-      expect(const Locale.fromSubtags(languageCode: 'ar', scriptCode: 'Arab'),
-          'ar_Arab'.toLocale());
+      expect(const Locale.fromSubtags(languageCode: 'ar', scriptCode: 'Arab'), 'ar_Arab'.toLocale());
       expect(
-          const Locale.fromSubtags(
-              languageCode: 'ar', scriptCode: 'Arab', countryCode: 'DZ'),
-          'ar_Arab_DZ'.toLocale());
+          const Locale.fromSubtags(languageCode: 'ar', scriptCode: 'Arab', countryCode: 'DZ'), 'ar_Arab_DZ'.toLocale());
     });
 
     test('load() Failed assertion', () async {
@@ -112,22 +100,15 @@ void main() {
     });
 
     test('load() correctly sets locale path', () async {
-      expect(
-          Localization.load(const Locale('en'), translations: r1.translations),
-          true);
+      expect(Localization.load(const Locale('en'), translations: r1.translations), true);
       expect(Localization.instance.tr('path'), 'path/en.json');
     });
 
     test('load() respects useOnlyLangCode', () async {
-      expect(
-          Localization.load(const Locale('en'), translations: r1.translations),
-          true);
+      expect(Localization.load(const Locale('en'), translations: r1.translations), true);
       expect(Localization.instance.tr('path'), 'path/en.json');
 
-      expect(
-          Localization.load(const Locale('en', 'us'),
-              translations: r2.translations),
-          true);
+      expect(Localization.load(const Locale('en', 'us'), translations: r2.translations), true);
       expect(Localization.instance.tr('path'), 'path/en-us.json');
     });
 
@@ -154,8 +135,7 @@ void main() {
     });
 
     /// E.g. if user saved a locale that was removed in a later version
-    test('controller loads fallback if saved locale is not supported',
-        () async {
+    test('controller loads fallback if saved locale is not supported', () async {
       SharedPreferences.setMockInitialValues({
         'locale': 'de',
       });
@@ -191,12 +171,9 @@ void main() {
         const zh = Locale('zh', '');
         const zh2 = Locale('zh', '');
         const zhCN = Locale('zh', 'CN');
-        const zhHans =
-            Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans');
-        const zhHant =
-            Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
-        const zhHansCN = Locale.fromSubtags(
-            languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN');
+        const zhHans = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans');
+        const zhHant = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
+        const zhHansCN = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN');
         expect(zh.supports(zhHansCN), isTrue);
         expect(zh2.supports(zhHansCN), isTrue);
         expect(zhCN.supports(zhHansCN), isTrue);
@@ -208,25 +185,22 @@ void main() {
       test('select locale from device locale', () {
         const en = Locale('en', '');
         const zh = Locale('zh', '');
-        const zhHans =
-            Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans');
-        const zhHant =
-            Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
-        const zhHansCN = Locale.fromSubtags(
-            languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN');
+        const zhHans = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans');
+        const zhHant = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
+        const zhHansCN = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hans', countryCode: 'CN');
 
         expect(
           EasyLocalizationController.selectLocaleFrom([en, zh], zhHansCN),
           zh,
         );
         expect(
-          EasyLocalizationController.selectLocaleFrom(
-              [zhHant, zhHans], zhHansCN),
+          EasyLocalizationController.selectLocaleFrom([zhHant, zhHans], zhHansCN),
           zhHans,
         );
       });
 
-      test('select best lenguage match if no perfect match exists', () { // #674
+      test('select best lenguage match if no perfect match exists', () {
+        // #674
         const userDeviceLocale = Locale('en', 'FR');
         const supportedLocale1 = Locale('en', 'US');
         const supportedLocale2 = Locale('zh', 'CN');
@@ -241,7 +215,8 @@ void main() {
         );
       });
 
-      test('select perfect match if exists', () { // #674
+      test('select perfect match if exists', () {
+        // #674
         const userDeviceLocale = Locale('en', 'GB');
         const supportedLocale1 = Locale('en', 'US');
         const supportedLocale2 = userDeviceLocale;
@@ -274,8 +249,7 @@ void main() {
       setUpAll(() async {
         await r.loadTranslations();
         Localization.load(const Locale('en'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
+            translations: r.translations, fallbackTranslations: r.fallbackTranslations);
       });
       test('finds and returns resource', () {
         expect(Localization.instance.tr('test'), 'test');
@@ -313,34 +287,25 @@ void main() {
       });
 
       test('can resolve linked locale messages and apply modifiers', () {
-        expect(Localization.instance.tr('linkAndModify'),
-            'this is linked and MODIFIED');
+        expect(Localization.instance.tr('linkAndModify'), 'this is linked and MODIFIED');
       });
 
-      test('can resolve multiple linked locale messages and apply modifiers',
-          () {
+      test('can resolve multiple linked locale messages and apply modifiers', () {
         expect(Localization.instance.tr('linkMany'), 'many Locale messages');
       });
 
       test('can resolve linked locale messages with brackets', () {
-        expect(Localization.instance.tr('linkedWithBrackets'),
-            'linked with brackets.');
+        expect(Localization.instance.tr('linkedWithBrackets'), 'linked with brackets.');
       });
 
       test('can resolve any number of nested arguments', () {
-        expect(
-            Localization.instance
-                .tr('nestedArguments', args: ['a', 'argument', '!']),
-            'this is a nested argument!');
+        expect(Localization.instance.tr('nestedArguments', args: ['a', 'argument', '!']), 'this is a nested argument!');
       });
 
       test('can resolve nested named arguments', () {
         expect(
-            Localization.instance.tr('nestedNamedArguments', namedArgs: {
-              'firstArg': 'this',
-              'secondArg': 'named argument',
-              'thirdArg': '!'
-            }),
+            Localization.instance.tr('nestedNamedArguments',
+                namedArgs: {'firstArg': 'this', 'secondArg': 'named argument', 'thirdArg': '!'}),
             'this is a nested named argument!');
       });
 
@@ -353,11 +318,9 @@ void main() {
         expect(Localization.instance.tr('test_missing'), 'test_missing');
         final logIterator = printLog.iterator;
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Localization key [test_missing] not found'));
+        expect(logIterator.current, contains('Localization key [test_missing] not found'));
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Fallback localization key [test_missing] not found'));
+        expect(logIterator.current, contains('Fallback localization key [test_missing] not found'));
       }));
 
       test('uses fallback translations', overridePrint(() {
@@ -368,8 +331,7 @@ void main() {
       test('reports missing resource with fallback', overridePrint(() {
         printLog = [];
         expect(Localization.instance.tr('test_missing_fallback'), 'fallback!');
-        expect(printLog.first,
-            contains('Localization key [test_missing_fallback] not found'));
+        expect(printLog.first, contains('Localization key [test_missing_fallback] not found'));
       }));
 
       test('uses empty translation, not using fallback', overridePrint(() {
@@ -386,8 +348,7 @@ void main() {
 
       test('returns resource and replaces argument in any nest level', () {
         expect(
-          Localization.instance
-              .tr('nested.super.duper.nested_with_arg', args: ['what a nest']),
+          Localization.instance.tr('nested.super.duper.nested_with_arg', args: ['what a nest']),
           'nested.super.duper.nested_with_arg what a nest',
         );
       });
@@ -399,25 +360,20 @@ void main() {
         );
       });
 
-      test(
-          'should raise exception if provided arguments length is different from the count of {} in the resource',
-          () {
+      test('should raise exception if provided arguments length is different from the count of {} in the resource', () {
         // @TODO
       });
 
       test('return resource and replaces named argument', () {
         expect(
-          Localization.instance.tr('test_replace_named',
-              namedArgs: {'arg1': 'one', 'arg2': 'two'}),
+          Localization.instance.tr('test_replace_named', namedArgs: {'arg1': 'one', 'arg2': 'two'}),
           'test named replace one two',
         );
       });
 
-      test('returns resource and replaces named argument in any nest level',
-          () {
+      test('returns resource and replaces named argument in any nest level', () {
         expect(
-          Localization.instance.tr('nested.super.duper.nested_with_named_arg',
-              namedArgs: {'arg': 'what a nest'}),
+          Localization.instance.tr('nested.super.duper.nested_with_named_arg', namedArgs: {'arg': 'what a nest'}),
           'nested.super.duper.nested_with_named_arg what a nest',
         );
       });
@@ -435,13 +391,11 @@ void main() {
 
       test('gender returns the correct resource and replaces args', () {
         expect(
-          Localization.instance
-              .tr('gender_and_replace', gender: 'male', args: ['one']),
+          Localization.instance.tr('gender_and_replace', gender: 'male', args: ['one']),
           'Hi one man ;)',
         );
         expect(
-          Localization.instance
-              .tr('gender_and_replace', gender: 'female', args: ['one']),
+          Localization.instance.tr('gender_and_replace', gender: 'female', args: ['one']),
           'Hello one girl :)',
         );
       });
@@ -479,8 +433,7 @@ void main() {
       test('reports empty resource with fallback', overridePrint(() {
         printLog = [];
         expect(Localization.instance.tr('test_empty_fallback'), 'fallback!');
-        expect(printLog.first,
-            contains('Localization key [test_empty_fallback] not found'));
+        expect(printLog.first, contains('Localization key [test_empty_fallback] not found'));
       }));
 
       test('reports empty resource', overridePrint(() {
@@ -488,11 +441,9 @@ void main() {
         expect(Localization.instance.tr('test_empty'), 'test_empty');
         final logIterator = printLog.iterator;
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Localization key [test_empty] not found'));
+        expect(logIterator.current, contains('Localization key [test_empty] not found'));
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Fallback localization key [test_empty] not found'));
+        expect(logIterator.current, contains('Fallback localization key [test_empty] not found'));
       }));
     });
 
@@ -513,8 +464,7 @@ void main() {
       setUpAll(() async {
         await r.loadTranslations();
         Localization.load(const Locale('fb'),
-            translations: r.translations,
-            fallbackTranslations: r.fallbackTranslations);
+            translations: r.translations, fallbackTranslations: r.fallbackTranslations);
       });
 
       test('zero', () {
@@ -544,8 +494,7 @@ void main() {
         expect(Localization.instance.plural('hat_other', 1), 'other hats');
       });
 
-      test('two as fallback and fallback translations priority',
-          overridePrint(() {
+      test('two as fallback and fallback translations priority', overridePrint(() {
         printLog = [];
         expect(
           Localization.instance.plural('test_fallback_plurals', 2),
@@ -554,66 +503,55 @@ void main() {
         expect(printLog, isEmpty);
       }));
 
-      test('two as fallback and fallback translations priority',
-          overridePrint(() {
-            printLog = [];
-            expect(
-              Localization.instance.plural('test_empty_fallback_plurals', 2),
-              '',
-            );
-            expect(printLog, isEmpty);
-          }));
+      test('two as fallback and fallback translations priority', overridePrint(() {
+        printLog = [];
+        expect(
+          Localization.instance.plural('test_empty_fallback_plurals', 2),
+          '',
+        );
+        expect(printLog, isEmpty);
+      }));
 
       test('with number format', () {
-        expect(
-            Localization.instance
-                .plural('day', 3, format: NumberFormat.currency()),
-            'USD3.00 other days');
+        expect(Localization.instance.plural('day', 3, format: NumberFormat.currency()), 'USD3.00 other days');
       });
 
       test('zero with args', () {
-        expect(Localization.instance.plural('money', 0, args: ['John', '0']),
-            'John has no money');
+        expect(Localization.instance.plural('money', 0, args: ['John', '0']), 'John has no money');
       });
 
       test('one with args', () {
-        expect(Localization.instance.plural('money', 1, args: ['John', '1']),
-            'John has 1 dollar');
+        expect(Localization.instance.plural('money', 1, args: ['John', '1']), 'John has 1 dollar');
       });
 
       test('other with args', () {
-        expect(Localization.instance.plural('money', 3, args: ['John', '3']),
-            'John has 3 dollars');
+        expect(Localization.instance.plural('money', 3, args: ['John', '3']), 'John has 3 dollars');
       });
 
       test('zero with named args', () {
         expect(
-          Localization.instance.plural('money_named_args', 0,
-              namedArgs: {'name': 'John', 'money': '0'}),
+          Localization.instance.plural('money_named_args', 0, namedArgs: {'name': 'John', 'money': '0'}),
           'John has no money',
         );
       });
 
       test('one with named args', () {
         expect(
-          Localization.instance.plural('money_named_args', 1,
-              namedArgs: {'name': 'John', 'money': '1'}),
+          Localization.instance.plural('money_named_args', 1, namedArgs: {'name': 'John', 'money': '1'}),
           'John has 1 dollar',
         );
       });
 
       test('other with named args', () {
         expect(
-          Localization.instance.plural('money_named_args', 3,
-              namedArgs: {'name': 'John', 'money': '3'}),
+          Localization.instance.plural('money_named_args', 3, namedArgs: {'name': 'John', 'money': '3'}),
           'John has 3 dollars',
         );
       });
 
       test('named args and value name', () {
         expect(
-          Localization.instance.plural('money_named_args', 3,
-              namedArgs: {'name': 'John'}, name: 'money'),
+          Localization.instance.plural('money_named_args', 3, namedArgs: {'name': 'John'}, name: 'money'),
           'John has 3 dollars',
         );
       });
@@ -643,8 +581,7 @@ void main() {
         );
       });
 
-      test('two as fallback for empty resource and fallback translations priority',
-          overridePrint(() {
+      test('two as fallback for empty resource and fallback translations priority', overridePrint(() {
         printLog = [];
         expect(
           Localization.instance.plural('test_empty_fallback_plurals', 2),
@@ -653,17 +590,13 @@ void main() {
         expect(printLog, isEmpty);
       }));
 
-      test('reports empty plural resource with fallback',
-          overridePrint(() {
+      test('reports empty plural resource with fallback', overridePrint(() {
         printLog = [];
         expect(
           Localization.instance.plural('test_empty_fallback_plurals', -1),
           'fallback other',
         );
-        expect(
-            printLog.first,
-            contains(
-                'Localization key [test_empty_fallback_plurals.other] not found'));
+        expect(printLog.first, contains('Localization key [test_empty_fallback_plurals.other] not found'));
       }));
 
       test('reports empty plural resource', overridePrint(() {
@@ -674,11 +607,9 @@ void main() {
         );
         final logIterator = printLog.iterator;
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Localization key [test_empty_plurals.other] not found'));
+        expect(logIterator.current, contains('Localization key [test_empty_plurals.other] not found'));
         logIterator.moveNext();
-        expect(logIterator.current,
-            contains('Fallback localization key [test_empty_plurals.other] not found'));
+        expect(logIterator.current, contains('Fallback localization key [test_empty_plurals.other] not found'));
       }));
     });
 

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -88,15 +88,14 @@ void main() async {
           assetLoader: const JsonAssetLoader(),
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
         expect(Localization.of(_context), isInstanceOf<Localization>());
         expect(Localization.instance, isInstanceOf<Localization>());
         expect(Localization.instance, Localization.of(_context));
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test');
@@ -121,12 +120,11 @@ void main() async {
           supportedLocales: const [Locale('en', 'US')],
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test_en-US');
@@ -147,12 +145,11 @@ void main() async {
           supportedLocales: const [Locale('en', 'US')],
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         final trFinder = find.text('test_en-US');
@@ -173,11 +170,10 @@ void main() async {
           supportedLocales: const [Locale('en', 'US')],
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
-        final trFinder =
-            find.byWidgetPredicate((widget) => widget is ErrorWidget);
+        final trFinder = find.byWidgetPredicate((widget) => widget is ErrorWidget);
         expect(trFinder, findsOneWidget);
         await tester.pump();
       });
@@ -192,12 +188,11 @@ void main() async {
           supportedLocales: const [Locale('en', 'US')],
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         var l = const Locale('en', 'US');
@@ -232,13 +227,12 @@ void main() async {
           supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
         expect(Localization.of(_context), isInstanceOf<Localization>());
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
         var trFinder = find.text('test_en-US');
@@ -255,23 +249,22 @@ void main() async {
 
         l = const Locale('ar', 'DZ');
         await EasyLocalization.of(_context)!.setLocale(l);
-        // await tester.idle();
+        await tester.idle();
         await tester.pump();
         expect(EasyLocalization.of(_context)!.locale, l);
 
         l = const Locale('en', 'US');
         await EasyLocalization.of(_context)!.setLocale(l);
-        // await tester.idle();
+        await tester.idle();
         await tester.pump();
         expect(EasyLocalization.of(_context)!.locale, l);
 
         l = const Locale('en', 'UK');
-        expect(() async => {await EasyLocalization.of(_context)!.setLocale(l)},
-            throwsAssertionError);
+        expect(() async => {await EasyLocalization.of(_context)!.setLocale(l)}, throwsAssertionError);
 
         l = const Locale('ar', 'DZ');
         await EasyLocalization.of(_context)!.setLocale(l);
-        // await tester.idle();
+        await tester.idle();
         await tester.pump();
         expect(EasyLocalization.of(_context)!.locale, l);
       });
@@ -289,12 +282,11 @@ void main() async {
           child: const MyApp(),
         ));
 
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        await EasyLocalization.of(_context)!
-            .setLocale(const Locale('ar', 'DZ'));
+        await EasyLocalization.of(_context)!.setLocale(const Locale('ar', 'DZ'));
 
         await tester.pump();
 
@@ -333,12 +325,11 @@ void main() async {
           supportedLocales: const [Locale('en'), Locale('ar')],
           child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en'), const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
 
         var l = const Locale('en');
@@ -359,12 +350,11 @@ void main() async {
           supportedLocales: const [Locale('en'), Locale('ar')],
           child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('en'), const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
 
         var l = const Locale('en');
@@ -386,15 +376,13 @@ void main() async {
           fallbackLocale: const Locale('ar'),
           child: const MyApp(),
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
-        expect(
-            EasyLocalization.of(_context)!.fallbackLocale, const Locale('ar'));
+        expect(EasyLocalization.of(_context)!.fallbackLocale, const Locale('ar'));
       });
     },
   );
@@ -411,12 +399,11 @@ void main() async {
           supportedLocales: const [Locale('ar')],
           child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
         ));
-        // await tester.idle();
+        await tester.idle();
         // The async delegator load will require build on the next frame. Thus, pump
         await tester.pump();
 
-        expect(EasyLocalization.of(_context)!.supportedLocales,
-            [const Locale('ar')]);
+        expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('ar')]);
         expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
         expect(EasyLocalization.of(_context)!.fallbackLocale, null);
       });
@@ -440,13 +427,12 @@ void main() async {
             supportedLocales: const [Locale('en'), Locale('ar')],
             child: const MyApp(), //
           ));
-          // await tester.idle();
+          await tester.idle();
           await tester.pump(const Duration(seconds: 2));
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en'), const Locale('ar')]);
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
           expect(EasyLocalization.of(_context)!.locale, const Locale('en'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
@@ -462,15 +448,13 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), //
           ));
-          // await tester.idle();
+          await tester.idle();
           await tester.pump(const Duration(seconds: 2));
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -486,15 +470,13 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), //
           ));
-          // await tester.idle();
+          await tester.idle();
           await tester.pump(const Duration(seconds: 2));
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -521,12 +503,11 @@ void main() async {
             supportedLocales: const [Locale('en'), Locale('ar')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en'), const Locale('ar')]);
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en'), const Locale('ar')]);
           expect(EasyLocalization.of(_context)!.locale, const Locale('ar'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
@@ -553,14 +534,12 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           expect(EasyLocalization.of(_context)!.fallbackLocale, null);
         });
       },
@@ -577,17 +556,14 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.supportedLocales,
-              [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.supportedLocales, [const Locale('en', 'US'), const Locale('ar', 'DZ')]);
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
 
-          await EasyLocalization.of(_context)!
-              .setLocale(const Locale('en', 'US'));
+          await EasyLocalization.of(_context)!.setLocale(const Locale('en', 'US'));
         });
       },
     );
@@ -609,12 +585,11 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           await EasyLocalization.of(_context)!.deleteSaveLocale();
         });
       },
@@ -630,12 +605,11 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -649,12 +623,11 @@ void main() async {
             supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')],
             child: const MyApp(), // Locale('en', 'US'), Locale('ar','DZ')
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(EasyLocalization.of(_context)!.deviceLocale.toString(),
-              Platform.localeName);
+          expect(EasyLocalization.of(_context)!.deviceLocale.toString(), Platform.localeName);
         });
       },
     );
@@ -665,24 +638,19 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
             path: '../../i18n',
-            supportedLocales: const [
-              Locale('en', 'US'),
-              Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: const Locale('ar', 'DZ'),
             child: const MyApp(),
           ));
-          // await tester.idle();
+          await tester.idle();
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pump();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           // reset to device locale
           await _context.resetLocale();
           await tester.pump();
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -700,8 +668,7 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
-          expect(EasyLocalization.of(_context)!.deviceLocale.toString(),
-              Platform.localeName);
+          expect(EasyLocalization.of(_context)!.deviceLocale.toString(), Platform.localeName);
         });
       },
     );
@@ -712,10 +679,7 @@ void main() async {
         await tester.runAsync(() async {
           await tester.pumpWidget(EasyLocalization(
             path: '../../i18n',
-            supportedLocales: const [
-              Locale('en', 'US'),
-              Locale('ar', 'DZ')
-            ], // Locale('en', 'US'), Locale('ar','DZ')
+            supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
             startLocale: const Locale('ar', 'DZ'),
             child: const MyApp(),
           ));
@@ -723,13 +687,11 @@ void main() async {
           // The async delegator load will require build on the next frame. Thus, pump
           await tester.pumpAndSettle();
 
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('ar', 'DZ'));
           // reset to device locale
           await _context.resetLocale();
           await tester.pumpAndSettle();
-          expect(
-              EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
+          expect(EasyLocalization.of(_context)!.locale, const Locale('en', 'US'));
         });
       },
     );
@@ -738,10 +700,7 @@ void main() async {
   group('Context extensions tests', () {
     final testWidget = EasyLocalization(
       path: '../../i18n',
-      supportedLocales: const [
-        Locale('en', 'US'),
-        Locale('ar', 'DZ')
-      ], // Locale('en', 'US'), Locale('ar','DZ')
+      supportedLocales: const [Locale('en', 'US'), Locale('ar', 'DZ')], // Locale('en', 'US'), Locale('ar','DZ')
       startLocale: const Locale('en', 'US'),
       child: const MyApp(
         child: MyLocalizedWidget(),
@@ -821,8 +780,7 @@ void main() async {
             true,
           );
           expect(
-            initialPluralValue != _contextPluralValue &&
-                _contextPluralValue == expectedArPluralTextWidgetValue,
+            initialPluralValue != _contextPluralValue && _contextPluralValue == expectedArPluralTextWidgetValue,
             true,
           );
         });

--- a/test/easy_localization_widget_test.dart
+++ b/test/easy_localization_widget_test.dart
@@ -116,7 +116,7 @@ void main() async {
       await tester.runAsync(() async {
         await tester.pumpWidget(EasyLocalization(
           path: '../../i18n',
-          assetLoader: const RootBundleAssetLoader(),
+          assetLoader: RootBundleAssetLoader.fromIOFile(),
           supportedLocales: const [Locale('en', 'US')],
           child: const MyApp(),
         ));

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -1,9 +1,11 @@
 import 'dart:ui';
 
-import 'package:easy_localization/src/asset_loader.dart';
+import 'package:easy_localization/easy_localization.dart'
+    show AssetLoader, JsonLinkedFileResolver, RootBundleFileLoader;
 
 class ImmutableJsonAssetLoader extends AssetLoader {
-  const ImmutableJsonAssetLoader();
+  const ImmutableJsonAssetLoader()
+      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
@@ -14,7 +16,7 @@ class ImmutableJsonAssetLoader extends AssetLoader {
 }
 
 class JsonAssetLoader extends AssetLoader {
-  const JsonAssetLoader();
+  const JsonAssetLoader() : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
@@ -25,10 +27,7 @@ class JsonAssetLoader extends AssetLoader {
       'test_replace_two': 'test replace {} {}',
       'test_replace_named': 'test named replace {arg1} {arg2}',
       'gender': {'male': 'Hi man ;)', 'female': 'Hello girl :)'},
-      'gender_and_replace': {
-        'male': 'Hi {} man ;)',
-        'female': 'Hello {} girl :)'
-      },
+      'gender_and_replace': {'male': 'Hi {} man ;)', 'female': 'Hello {} girl :)'},
       'day': {
         'zero': '{} days',
         'one': '{} day',
@@ -80,14 +79,12 @@ class JsonAssetLoader extends AssetLoader {
           'duper': {
             'nested': 'nested.super.duper.nested',
             'nested_with_arg': 'nested.super.duper.nested_with_arg {}',
-            'nested_with_named_arg':
-                'nested.super.duper.nested_with_named_arg {arg}'
+            'nested_with_named_arg': 'nested.super.duper.nested_with_named_arg {arg}'
           }
         }
       },
       'path': fullPath,
-      'test_missing_fallback':
-          (locale.languageCode == 'fb' ? 'fallback!' : null),
+      'test_missing_fallback': (locale.languageCode == 'fb' ? 'fallback!' : null),
       'test_empty_fallback': (locale.languageCode == 'fb' ? 'fallback!' : ''),
       'test_fallback_plurals': (locale.languageCode == 'fb'
           ? {
@@ -121,31 +118,31 @@ class JsonAssetLoader extends AssetLoader {
             }),
       'test_empty_plurals': (locale.languageCode == 'fb'
           ? {
-        'zero': '',
-        'one': '',
-        'two': '',
-        'few': '',
-        'many': '',
-        'other': '',
-      }
+              'zero': '',
+              'one': '',
+              'two': '',
+              'few': '',
+              'many': '',
+              'other': '',
+            }
           : {
-        'zero': '',
-        'one': '',
-        'two': '',
-        'few': '',
-        'many': '',
-        'other': '',
-      })
+              'zero': '',
+              'one': '',
+              'two': '',
+              'few': '',
+              'many': '',
+              'other': '',
+            })
     });
   }
 }
 
 class ExternalAssetLoader extends AssetLoader {
-  const ExternalAssetLoader();
+  const ExternalAssetLoader()
+      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
   @override
-  Future<Map<String, dynamic>> load(String fullPath, Locale locale) =>
-      Future.value(const {
+  Future<Map<String, dynamic>> load(String fullPath, Locale locale) => Future.value(const {
         'package_value_01': 'package_value_01',
         'package_value_02': 'package_value_02',
         'package_value_03': 'package_value_03',
@@ -153,11 +150,11 @@ class ExternalAssetLoader extends AssetLoader {
 }
 
 class NestedAssetLoader extends AssetLoader {
-  const NestedAssetLoader();
+  const NestedAssetLoader()
+      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
 
   @override
-  Future<Map<String, dynamic>> load(String fullPath, Locale locale) =>
-      Future.value({
+  Future<Map<String, dynamic>> load(String fullPath, Locale locale) => Future.value({
         'nested': {
           'super': {
             'duper': {'nested': 'nested.super.duper.nested'}

--- a/test/utils/test_asset_loaders.dart
+++ b/test/utils/test_asset_loaders.dart
@@ -5,7 +5,9 @@ import 'package:easy_localization/easy_localization.dart'
 
 class ImmutableJsonAssetLoader extends AssetLoader {
   const ImmutableJsonAssetLoader()
-      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+      : super(
+            linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+            fileLoader: const RootBundleFileLoader());
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
@@ -16,7 +18,10 @@ class ImmutableJsonAssetLoader extends AssetLoader {
 }
 
 class JsonAssetLoader extends AssetLoader {
-  const JsonAssetLoader() : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+  const JsonAssetLoader()
+      : super(
+            linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+            fileLoader: const RootBundleFileLoader());
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) {
@@ -138,8 +143,10 @@ class JsonAssetLoader extends AssetLoader {
 }
 
 class ExternalAssetLoader extends AssetLoader {
-  const ExternalAssetLoader()
-      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+  ExternalAssetLoader()
+      : super(
+            linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+            fileLoader: const RootBundleFileLoader());
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) => Future.value(const {
@@ -150,8 +157,10 @@ class ExternalAssetLoader extends AssetLoader {
 }
 
 class NestedAssetLoader extends AssetLoader {
-  const NestedAssetLoader()
-      : super(linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()));
+  NestedAssetLoader()
+      : super(
+            linkedFileResolver: const JsonLinkedFileResolver(fileLoader: RootBundleFileLoader()),
+            fileLoader: const RootBundleFileLoader());
 
   @override
   Future<Map<String, dynamic>> load(String fullPath, Locale locale) => Future.value({


### PR DESCRIPTION
Allow user to split the translations files to keep translations maintanable.

An update will be needed on easy localization loader one this is pushed to pub.

**Breaking changes** : The asset loader now use a linked file loader and a file loader, so all class extending them will need to add the super parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Split a locale’s translations across linked JSON files using a :/ path syntax; supports deep nesting, composition, and detects/report cycles or missing links.
  - Supports loading linked files from bundled assets and CLI/IO sources.

- **Documentation**
  - Added "Linked files" instructions explaining syntax, asset inclusion, and default JSON loader requirements.

- **Tests**
  - New tests covering single/multiple links, nested/deep nesting, structure preservation, error cases, and language-code-only loads.

- **Behavior**
  - Added fallback handling for empty resources and improved locale name handling in tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->