### PR TITLE
Feature/generator yaml support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+### [3.0.9]
+
+- added .yaml support for transaltion files in the :generate script
+ 
 ### [3.0.8]
 
 - code audit and maintenance updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### [3.0.9]
 
-- added .yaml support for transaltion files in the :generate script
+- added .yaml support for translation files in the :generate script
  
 ### [3.0.8]
 

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -44,45 +44,35 @@ GenerateOptions _generateOption(List<String> args) {
 ArgParser _generateArgParser(GenerateOptions? generateOptions) {
   var parser = ArgParser();
 
-  parser.addOption(
-    'source-dir',
-    abbr: 'S',
-    defaultsTo: 'resources/langs',
-    callback: (String? x) => generateOptions!.sourceDir = x,
-    help: 'Folder containing localization files',
-  );
+  parser.addOption('source-dir',
+      abbr: 'S',
+      defaultsTo: 'resources/langs',
+      callback: (String? x) => generateOptions!.sourceDir = x,
+      help: 'Folder containing localization files');
 
-  parser.addOption(
-    'source-file',
-    abbr: 's',
-    callback: (String? x) => generateOptions!.sourceFile = x,
-    help: 'File to use for localization',
-  );
+  parser.addOption('source-file',
+      abbr: 's',
+      callback: (String? x) => generateOptions!.sourceFile = x,
+      help: 'File to use for localization');
 
-  parser.addOption(
-    'output-dir',
-    abbr: 'O',
-    defaultsTo: 'lib/generated',
-    callback: (String? x) => generateOptions!.outputDir = x,
-    help: 'Output folder stores for the generated file',
-  );
+  parser.addOption('output-dir',
+      abbr: 'O',
+      defaultsTo: 'lib/generated',
+      callback: (String? x) => generateOptions!.outputDir = x,
+      help: 'Output folder stores for the generated file');
 
-  parser.addOption(
-    'output-file',
-    abbr: 'o',
-    defaultsTo: 'codegen_loader.g.dart',
-    callback: (String? x) => generateOptions!.outputFile = x,
-    help: 'Output file name',
-  );
+  parser.addOption('output-file',
+      abbr: 'o',
+      defaultsTo: 'codegen_loader.g.dart',
+      callback: (String? x) => generateOptions!.outputFile = x,
+      help: 'Output file name');
 
-  parser.addOption(
-    'format',
-    abbr: 'f',
-    defaultsTo: 'json',
-    callback: (String? x) => generateOptions!.format = x,
-    help: 'Support json or keys formats',
-    allowed: ['json', 'keys'],
-  );
+  parser.addOption('format',
+      abbr: 'f',
+      defaultsTo: 'json',
+      callback: (String? x) => generateOptions!.format = x,
+      help: 'Support json, yaml, or keys formats',
+      allowed: ['json', 'yaml', 'keys']);
 
   parser.addFlag(
     'skip-unnecessary-keys',
@@ -115,9 +105,8 @@ void handleLangFiles(GenerateOptions options) async {
   final source = Directory.fromUri(Uri.parse(options.sourceDir!));
   final output = Directory.fromUri(Uri.parse(options.outputDir!));
   final sourcePath = Directory(path.join(current.path, source.path));
-  final outputPath = Directory(
-    path.join(current.path, output.path, options.outputFile),
-  );
+  final outputPath =
+      Directory(path.join(current.path, output.path, options.outputFile));
 
   if (!await sourcePath.exists()) {
     stderr.writeln('Source path does not exist');
@@ -133,10 +122,8 @@ void handleLangFiles(GenerateOptions options) async {
     }
     files = [sourceFile];
   } else {
-    // Filter for .yml and .yaml files
-    files = files
-        .where((f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
-        .toList();
+    //filtering format
+    files = files.where((f) => f.path.contains(RegExp(r'\.(json|yaml|yml)$'))).toList();
   }
 
   if (files.isNotEmpty) {
@@ -150,18 +137,13 @@ Future<List<FileSystemEntity>> dirContents(Directory dir) {
   var files = <FileSystemEntity>[];
   var completer = Completer<List<FileSystemEntity>>();
   var lister = dir.list(recursive: false);
-  lister.listen(
-    (file) => files.add(file),
-    onDone: () => completer.complete(files),
-  );
+  lister.listen((file) => files.add(file),
+      onDone: () => completer.complete(files));
   return completer.future;
 }
 
-void generateFile(
-  List<FileSystemEntity> files,
-  Directory outputPath,
-  GenerateOptions options,
-) async {
+void generateFile(List<FileSystemEntity> files, Directory outputPath,
+    GenerateOptions options) async {
   var generatedFile = File(outputPath.path);
   if (!generatedFile.existsSync()) {
     generatedFile.createSync(recursive: true);
@@ -172,6 +154,9 @@ void generateFile(
   switch (options.format) {
     case 'json':
       await _writeJson(classBuilder, files);
+      break;
+    case 'yaml':
+      await _writeYaml(classBuilder, files);
       break;
     case 'keys':
       await _writeKeys(classBuilder, files, options.skipUnnecessaryKeys);
@@ -186,36 +171,28 @@ void generateFile(
   stdout.writeln('All done! File generated in ${outputPath.path}');
 }
 
-Future _writeKeys(
-  StringBuffer classBuilder,
-  List<FileSystemEntity> files,
-  bool? skipUnnecessaryKeys,
-) async {
+Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
+    bool? skipUnnecessaryKeys) async {
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
 // ignore_for_file: constant_identifier_names
 
-abstract class LocaleKeys {
+abstract class  LocaleKeys {
 ''';
 
   final fileData = File(files.first.path);
 
-  // Parse YAML file
-  final yamlString = await fileData.readAsString();
-  final yamlData = loadYaml(yamlString);
-  Map<String, dynamic> translations = _yamlToMap(yamlData);
+  Map<String, dynamic> translations =
+      json.decode(json.encode(loadYaml(await fileData.readAsString())));
 
   file += _resolve(translations, skipUnnecessaryKeys);
 
   classBuilder.writeln(file);
 }
 
-String _resolve(
-  Map<String, dynamic> translations,
-  bool? skipUnnecessaryKeys, [
-  String? accKey,
-]) {
+String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
+    [String? accKey]) {
   var fileContent = '';
 
   final sortedKeys = translations.keys.toList();
@@ -229,10 +206,8 @@ String _resolve(
     var ignoreKey = false;
     if (translations[key] is Map) {
       // If key does not contain keys for plural(), gender() etc. and option is enabled -> ignore it
-      ignoreKey =
-          !containsPreservedKeywords(
-            translations[key] as Map<String, dynamic>,
-          ) &&
+      ignoreKey = !containsPreservedKeywords(
+              translations[key] as Map<String, dynamic>) &&
           canIgnoreKeys;
 
       var nextAccKey = key;
@@ -240,20 +215,17 @@ String _resolve(
         nextAccKey = '$accKey.$key';
       }
 
-      fileContent += _resolve(
-        translations[key],
-        skipUnnecessaryKeys,
-        nextAccKey,
-      );
+      fileContent +=
+          _resolve(translations[key], skipUnnecessaryKeys, nextAccKey);
     }
 
     if (!_preservedKeywords.contains(key)) {
       accKey != null && !ignoreKey
           ? fileContent +=
-                '  static const ${accKey.replaceAll('.', '_')}_$key = \'$accKey.$key\';\n'
+              '  static const ${accKey.replaceAll('.', '_')}_$key = \'$accKey.$key\';\n'
           : !ignoreKey
-          ? fileContent += '  static const $key = \'$key\';\n'
-          : null;
+              ? fileContent += '  static const $key = \'$key\';\n'
+              : null;
     }
   }
 
@@ -261,9 +233,7 @@ String _resolve(
 }
 
 Future _writeJson(
-  StringBuffer classBuilder,
-  List<FileSystemEntity> files,
-) async {
+    StringBuffer classBuilder, List<FileSystemEntity> files) async {
   var gFile = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
@@ -273,7 +243,47 @@ import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart' show AssetLoader;
 
-class CodegenLoader extends AssetLoader {
+class CodegenLoader extends AssetLoader{
+  const CodegenLoader();
+
+  @override
+  Future<Map<String, dynamic>?> load(String path, Locale locale) {
+    return Future.value(mapLocales[locale.toString()]);
+  }
+
+  ''';
+
+  final listLocales = [];
+
+  for (var file in files) {
+    final localeName =
+        path.basename(file.path).replaceFirst('.json', '').replaceAll('-', '_');
+    listLocales.add('"$localeName": _$localeName');
+    final fileData = File(file.path);
+
+    Map<String, dynamic>? data = json.decode(await fileData.readAsString());
+
+    final mapString = const JsonEncoder.withIndent('  ').convert(data);
+    gFile += 'static const Map<String,dynamic> _$localeName = $mapString;\n';
+  }
+
+  gFile +=
+      'static const Map<String, Map<String,dynamic>> mapLocales = {${listLocales.join(', ')}};';
+  classBuilder.writeln(gFile);
+}
+
+Future _writeYaml(
+    StringBuffer classBuilder, List<FileSystemEntity> files) async {
+  var gFile = '''
+// DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
+
+// ignore_for_file: prefer_single_quotes, avoid_renaming_method_parameters, constant_identifier_names
+
+import 'dart:ui';
+
+import 'package:easy_localization/easy_localization.dart' show AssetLoader;
+
+class CodegenLoader extends AssetLoader{
   const CodegenLoader();
 
   @override
@@ -288,16 +298,12 @@ class CodegenLoader extends AssetLoader {
   for (var file in files) {
     final localeName = path
         .basename(file.path)
-        .replaceFirst(RegExp(r'\.ya?ml$'), '')
+        .replaceFirst(RegExp(r'\.(yaml|yml)'), '')
         .replaceAll('-', '_');
     listLocales.add('"$localeName": _$localeName');
     final fileData = File(file.path);
 
-    // Parse YAML file
-    final yamlString = await fileData.readAsString();
-    final yamlData = loadYaml(yamlString);
-    Map<String, dynamic> data = _yamlToMap(yamlData);
-
+    var data = loadYaml(await fileData.readAsString());
     final mapString = const JsonEncoder.withIndent('  ').convert(data);
     gFile += 'static const Map<String,dynamic> _$localeName = $mapString;\n';
   }
@@ -305,19 +311,4 @@ class CodegenLoader extends AssetLoader {
   gFile +=
       'static const Map<String, Map<String,dynamic>> mapLocales = {${listLocales.join(', ')}};';
   classBuilder.writeln(gFile);
-}
-
-// Helper function to convert YamlMap to Map<String, dynamic>
-Map<String, dynamic> _yamlToMap(dynamic yaml) {
-  if (yaml is YamlMap) {
-    return yaml.map((key, value) {
-      if (value is YamlMap || value is YamlList) {
-        return MapEntry(key.toString(), _yamlToMap(value));
-      }
-      return MapEntry(key.toString(), value);
-    });
-  } else if (yaml is YamlList) {
-    return {'': yaml.map((e) => _yamlToMap(e)).toList()};
-  }
-  return {};
 }

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
 
 const _preservedKeywords = [
   'few',
@@ -43,35 +44,45 @@ GenerateOptions _generateOption(List<String> args) {
 ArgParser _generateArgParser(GenerateOptions? generateOptions) {
   var parser = ArgParser();
 
-  parser.addOption('source-dir',
-      abbr: 'S',
-      defaultsTo: 'resources/langs',
-      callback: (String? x) => generateOptions!.sourceDir = x,
-      help: 'Folder containing localization files');
+  parser.addOption(
+    'source-dir',
+    abbr: 'S',
+    defaultsTo: 'resources/langs',
+    callback: (String? x) => generateOptions!.sourceDir = x,
+    help: 'Folder containing localization files',
+  );
 
-  parser.addOption('source-file',
-      abbr: 's',
-      callback: (String? x) => generateOptions!.sourceFile = x,
-      help: 'File to use for localization');
+  parser.addOption(
+    'source-file',
+    abbr: 's',
+    callback: (String? x) => generateOptions!.sourceFile = x,
+    help: 'File to use for localization',
+  );
 
-  parser.addOption('output-dir',
-      abbr: 'O',
-      defaultsTo: 'lib/generated',
-      callback: (String? x) => generateOptions!.outputDir = x,
-      help: 'Output folder stores for the generated file');
+  parser.addOption(
+    'output-dir',
+    abbr: 'O',
+    defaultsTo: 'lib/generated',
+    callback: (String? x) => generateOptions!.outputDir = x,
+    help: 'Output folder stores for the generated file',
+  );
 
-  parser.addOption('output-file',
-      abbr: 'o',
-      defaultsTo: 'codegen_loader.g.dart',
-      callback: (String? x) => generateOptions!.outputFile = x,
-      help: 'Output file name');
+  parser.addOption(
+    'output-file',
+    abbr: 'o',
+    defaultsTo: 'codegen_loader.g.dart',
+    callback: (String? x) => generateOptions!.outputFile = x,
+    help: 'Output file name',
+  );
 
-  parser.addOption('format',
-      abbr: 'f',
-      defaultsTo: 'json',
-      callback: (String? x) => generateOptions!.format = x,
-      help: 'Support json or keys formats',
-      allowed: ['json', 'keys']);
+  parser.addOption(
+    'format',
+    abbr: 'f',
+    defaultsTo: 'json',
+    callback: (String? x) => generateOptions!.format = x,
+    help: 'Support json or keys formats',
+    allowed: ['json', 'keys'],
+  );
 
   parser.addFlag(
     'skip-unnecessary-keys',
@@ -104,8 +115,9 @@ void handleLangFiles(GenerateOptions options) async {
   final source = Directory.fromUri(Uri.parse(options.sourceDir!));
   final output = Directory.fromUri(Uri.parse(options.outputDir!));
   final sourcePath = Directory(path.join(current.path, source.path));
-  final outputPath =
-      Directory(path.join(current.path, output.path, options.outputFile));
+  final outputPath = Directory(
+    path.join(current.path, output.path, options.outputFile),
+  );
 
   if (!await sourcePath.exists()) {
     stderr.writeln('Source path does not exist');
@@ -121,8 +133,10 @@ void handleLangFiles(GenerateOptions options) async {
     }
     files = [sourceFile];
   } else {
-    //filtering format
-    files = files.where((f) => f.path.contains('.json')).toList();
+    // Filter for .yml and .yaml files
+    files = files
+        .where((f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+        .toList();
   }
 
   if (files.isNotEmpty) {
@@ -136,13 +150,18 @@ Future<List<FileSystemEntity>> dirContents(Directory dir) {
   var files = <FileSystemEntity>[];
   var completer = Completer<List<FileSystemEntity>>();
   var lister = dir.list(recursive: false);
-  lister.listen((file) => files.add(file),
-      onDone: () => completer.complete(files));
+  lister.listen(
+    (file) => files.add(file),
+    onDone: () => completer.complete(files),
+  );
   return completer.future;
 }
 
-void generateFile(List<FileSystemEntity> files, Directory outputPath,
-    GenerateOptions options) async {
+void generateFile(
+  List<FileSystemEntity> files,
+  Directory outputPath,
+  GenerateOptions options,
+) async {
   var generatedFile = File(outputPath.path);
   if (!generatedFile.existsSync()) {
     generatedFile.createSync(recursive: true);
@@ -157,9 +176,6 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
     case 'keys':
       await _writeKeys(classBuilder, files, options.skipUnnecessaryKeys);
       break;
-    // case 'csv':
-    //   await _writeCsv(classBuilder, files);
-    // break;
     default:
       stderr.writeln('Format not supported');
   }
@@ -170,28 +186,36 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
   stdout.writeln('All done! File generated in ${outputPath.path}');
 }
 
-Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
-    bool? skipUnnecessaryKeys) async {
+Future _writeKeys(
+  StringBuffer classBuilder,
+  List<FileSystemEntity> files,
+  bool? skipUnnecessaryKeys,
+) async {
   var file = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  LocaleKeys {
+abstract class LocaleKeys {
 ''';
 
   final fileData = File(files.first.path);
 
-  Map<String, dynamic> translations =
-      json.decode(await fileData.readAsString());
+  // Parse YAML file
+  final yamlString = await fileData.readAsString();
+  final yamlData = loadYaml(yamlString);
+  Map<String, dynamic> translations = _yamlToMap(yamlData);
 
   file += _resolve(translations, skipUnnecessaryKeys);
 
   classBuilder.writeln(file);
 }
 
-String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
-    [String? accKey]) {
+String _resolve(
+  Map<String, dynamic> translations,
+  bool? skipUnnecessaryKeys, [
+  String? accKey,
+]) {
   var fileContent = '';
 
   final sortedKeys = translations.keys.toList();
@@ -205,8 +229,10 @@ String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
     var ignoreKey = false;
     if (translations[key] is Map) {
       // If key does not contain keys for plural(), gender() etc. and option is enabled -> ignore it
-      ignoreKey = !containsPreservedKeywords(
-              translations[key] as Map<String, dynamic>) &&
+      ignoreKey =
+          !containsPreservedKeywords(
+            translations[key] as Map<String, dynamic>,
+          ) &&
           canIgnoreKeys;
 
       var nextAccKey = key;
@@ -214,17 +240,20 @@ String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
         nextAccKey = '$accKey.$key';
       }
 
-      fileContent +=
-          _resolve(translations[key], skipUnnecessaryKeys, nextAccKey);
+      fileContent += _resolve(
+        translations[key],
+        skipUnnecessaryKeys,
+        nextAccKey,
+      );
     }
 
     if (!_preservedKeywords.contains(key)) {
       accKey != null && !ignoreKey
           ? fileContent +=
-              '  static const ${accKey.replaceAll('.', '_')}_$key = \'$accKey.$key\';\n'
+                '  static const ${accKey.replaceAll('.', '_')}_$key = \'$accKey.$key\';\n'
           : !ignoreKey
-              ? fileContent += '  static const $key = \'$key\';\n'
-              : null;
+          ? fileContent += '  static const $key = \'$key\';\n'
+          : null;
     }
   }
 
@@ -232,7 +261,9 @@ String _resolve(Map<String, dynamic> translations, bool? skipUnnecessaryKeys,
 }
 
 Future _writeJson(
-    StringBuffer classBuilder, List<FileSystemEntity> files) async {
+  StringBuffer classBuilder,
+  List<FileSystemEntity> files,
+) async {
   var gFile = '''
 // DO NOT EDIT. This is code generated via package:easy_localization/generate.dart
 
@@ -242,7 +273,7 @@ import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart' show AssetLoader;
 
-class CodegenLoader extends AssetLoader{
+class CodegenLoader extends AssetLoader {
   const CodegenLoader();
 
   @override
@@ -255,12 +286,17 @@ class CodegenLoader extends AssetLoader{
   final listLocales = [];
 
   for (var file in files) {
-    final localeName =
-        path.basename(file.path).replaceFirst('.json', '').replaceAll('-', '_');
+    final localeName = path
+        .basename(file.path)
+        .replaceFirst(RegExp(r'\.ya?ml$'), '')
+        .replaceAll('-', '_');
     listLocales.add('"$localeName": _$localeName');
     final fileData = File(file.path);
 
-    Map<String, dynamic>? data = json.decode(await fileData.readAsString());
+    // Parse YAML file
+    final yamlString = await fileData.readAsString();
+    final yamlData = loadYaml(yamlString);
+    Map<String, dynamic> data = _yamlToMap(yamlData);
 
     final mapString = const JsonEncoder.withIndent('  ').convert(data);
     gFile += 'static const Map<String,dynamic> _$localeName = $mapString;\n';
@@ -271,22 +307,17 @@ class CodegenLoader extends AssetLoader{
   classBuilder.writeln(gFile);
 }
 
-// _writeCsv(StringBuffer classBuilder, List<FileSystemEntity> files) async {
-//   List<String> listLocales = List();
-//   final fileData = File(files.first.path);
-
-//   // CSVParser csvParser = CSVParser(await fileData.readAsString());
-
-//   // List listLangs = csvParser.getLanguages();
-//   for(String localeName in listLangs){
-//     listLocales.add('"$localeName": $localeName');
-//     String mapString = JsonEncoder.withIndent("  ").convert(csvParser.getLanguageMap(localeName)) ;
-
-//     classBuilder.writeln(
-//       '  static const Map<String,dynamic> $localeName = ${mapString};\n');
-//   }
-
-//   classBuilder.writeln(
-//       '  static const Map<String, Map<String,dynamic>> mapLocales = \{${listLocales.join(', ')}\};');
-
-// }
+// Helper function to convert YamlMap to Map<String, dynamic>
+Map<String, dynamic> _yamlToMap(dynamic yaml) {
+  if (yaml is YamlMap) {
+    return yaml.map((key, value) {
+      if (value is YamlMap || value is YamlList) {
+        return MapEntry(key.toString(), _yamlToMap(value));
+      }
+      return MapEntry(key.toString(), value);
+    });
+  } else if (yaml is YamlList) {
+    return {'': yaml.map((e) => _yamlToMap(e)).toList()};
+  }
+  return {};
+}

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -161,6 +161,9 @@ void generateFile(List<FileSystemEntity> files, Directory outputPath,
     case 'keys':
       await _writeKeys(classBuilder, files, options.skipUnnecessaryKeys);
       break;
+    // case 'csv':
+    //   await _writeCsv(classBuilder, files);
+    // break;
     default:
       stderr.writeln('Format not supported');
   }
@@ -312,3 +315,23 @@ class CodegenLoader extends AssetLoader{
       'static const Map<String, Map<String,dynamic>> mapLocales = {${listLocales.join(', ')}};';
   classBuilder.writeln(gFile);
 }
+
+// _writeCsv(StringBuffer classBuilder, List<FileSystemEntity> files) async {
+//   List<String> listLocales = List();
+//   final fileData = File(files.first.path);
+
+//   // CSVParser csvParser = CSVParser(await fileData.readAsString());
+
+//   // List listLangs = csvParser.getLanguages();
+//   for(String localeName in listLangs){
+//     listLocales.add('"$localeName": $localeName');
+//     String mapString = JsonEncoder.withIndent("  ").convert(csvParser.getLanguageMap(localeName)) ;
+
+//     classBuilder.writeln(
+//       '  static const Map<String,dynamic> $localeName = ${mapString};\n');
+//   }
+
+//   classBuilder.writeln(
+//       '  static const Map<String, Map<String,dynamic>> mapLocales = \{${listLocales.join(', ')}\};');
+
+// }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   intl: '>=0.17.0-0 <0.21.0'
   args: ^2.3.1
   path: ^1.8.1
+  yaml: ^3.1.2
   easy_logger: ^0.0.2
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
Extended the generate class to support generation of LocaleKeys from a yaml file.

This helps structuring the translations with comments which .json does not allow. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Add support for YAML translation files (.yml/.yaml) in the generate workflow; CLI format option now accepts "yaml" while preserving existing JSON behavior.
- Documentation
  - Added a 3.0.9 changelog entry announcing YAML support.
- Chores
  - Added a YAML parsing dependency to enable YAML input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->