### PR TITLE
[FIX] Audit command return non zero exit code on missing keys and handling plural and gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ If you are not using the default translations folder path (assets/translations) 
 | ---------------------------- | ----- | --------------------- | --------------------------------------------------------------------------- |
 | --translations-dir           | -t    | assets/translations   | Folder containing localization files                                        |
 | --source-dir                 | -s    | lib                   | Folder containing the app code files                                        |
+| --show-warnings              | -w    | false                 | show the warning (keys that contains variables and thus cannot be verified) |
 
 ### Errors : 
 

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ print(LocaleKeys.title.tr()); //String
 Text(LocaleKeys.title).tr(); //Widget
 ```
 
-### ✅ Audit missing keys
+## ✅ Audit missing keys
 
 If you prefer to not generate keys you can see an audit of your translation keys to see the one present in your app code but not in your translations file by running the audit command.
 
@@ -580,12 +580,20 @@ If you prefer to not generate keys you can see an audit of your translation keys
 flutter pub run easy_localization:audit
 ```
 
+### Arguments :
+
 If you are not using the default translations folder path (assets/translations) or the lib folder for your code you can specify your custom paths : 
 
 | Arguments                    | Short | Default               | Description                                                                 |
 | ---------------------------- | ----- | --------------------- | --------------------------------------------------------------------------- |
 | --translations-dir           | -t    | assets/translations   | Folder containing localization files                                        |
 | --source-dir                 | -s    | lib                   | Folder containing the app code files                                        |
+
+### Errors : 
+
+| Code | Description                                                                          | 
+| ---- | ------------------------------------------------------------------------------------ |
+| 1    | Some keys are used in the code that are not present in one of the localization keys  |
 
 ## 🖨️ Logger
 

--- a/bin/audit.dart
+++ b/bin/audit.dart
@@ -9,11 +9,13 @@ void main(List<String> args) {
 
   parser.addOption('translations-dir', abbr: 't', defaultsTo: 'assets/translations');
   parser.addOption('source-dir', abbr: 's', defaultsTo: 'lib');
+  parser.addFlag('show-warnings', abbr: 'w', defaultsTo: false);
 
   try {
     var argResults = parser.parse(actual);
     final transDir = argResults['translations-dir'] as String;
     final srcDir = argResults['source-dir'] as String;
+    final showWarnings = argResults['show-warnings'] as bool;
 
     if (!Directory(transDir).existsSync()) {
       stderr.writeln('Error: Translation directory "$transDir" does not exist.');
@@ -25,7 +27,7 @@ void main(List<String> args) {
       exit(1);
     }
 
-    AuditCommand().run(transDir: transDir, srcDir: srcDir);
+    AuditCommand().run(transDir: transDir, srcDir: srcDir, showWarnings: showWarnings);
   } catch (e) {
     stderr.writeln('Error: $e');
     exit(1);

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'key_parser.dart';
 
 class AuditCommand {
-  Future<void> run({required String transDir, required String srcDir}) async {
+  Future<void> run({required String transDir, required String srcDir, required bool showWarnings}) async {
     try {
       final translationDir = Directory(transDir);
       final sourceDir = Directory(srcDir);
@@ -21,13 +21,13 @@ class AuditCommand {
       final allTranslations = await keyParser.parseKeysInTranslationsDir(translationDir);
       final usedKeys = keyParser.parseKeysInSourceDir(sourceDir);
 
-      _report(allTranslations, usedKeys);
+      _report(allTranslations, usedKeys, showWarnings: showWarnings);
     } catch (e) {
       stderr.writeln('Error during audit: $e');
     }
   }
 
-  void _report(Map<String, Set<String>> allTranslations, Set<String> usedKeys) {
+  void _report(Map<String, Set<String>> allTranslations, Set<String> usedKeys, {required bool showWarnings}) {
     stderr.writeln('=== Keys Audit ===');
 
     for (var lang in allTranslations.keys) {
@@ -37,7 +37,7 @@ class AuditCommand {
       final missingWithoutVariables = missing.where((key) => !key.contains('\$')).toList();
 
       stderr.writeln('\nLanguage: $lang');
-      if (missingWithVariables.isEmpty && missingWithoutVariables.isEmpty) {
+      if ((missingWithVariables.isEmpty || !showWarnings) && missingWithoutVariables.isEmpty) {
         stderr.writeln('  ✅ all good!');
       }
 
@@ -51,7 +51,7 @@ class AuditCommand {
         exit(1);
       }
 
-      if (missingWithVariables.isNotEmpty) {
+      if (missingWithVariables.isNotEmpty && showWarnings) {
         stderr.writeln('  🟡 Missing with variables (${missingWithVariables.length}):');
         stderr.writeln('    These keys may not be missing as they contain variables that cannot be verified.');
         for (var key in missingWithVariables) {

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -154,6 +154,7 @@ class AuditCommand {
         }
 
         stderr.writeln('\n');
+        exit(1);
       }
 
       if (missingWithVariables.isNotEmpty) {

--- a/bin/audit/audit_command.dart
+++ b/bin/audit/audit_command.dart
@@ -1,8 +1,5 @@
-import 'dart:convert';
 import 'dart:io';
-import 'package:easy_localization/src/linked_file_resolver.dart';
-import 'package:path/path.dart';
-import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
+import 'key_parser.dart';
 
 class AuditCommand {
   Future<void> run({required String transDir, required String srcDir}) async {
@@ -20,117 +17,14 @@ class AuditCommand {
         return;
       }
 
-      final allTranslations = await _loadTranslations(translationDir);
-      final usedKeys = _scanSourceForKeys(sourceDir);
+      final keyParser = KeyParser();
+      final allTranslations = await keyParser.parseKeysInTranslationsDir(translationDir);
+      final usedKeys = keyParser.parseKeysInSourceDir(sourceDir);
 
       _report(allTranslations, usedKeys);
     } catch (e) {
       stderr.writeln('Error during audit: $e');
     }
-  }
-
-  /// Walks [translationsDir], reads every `.json`, flattens nested maps
-  /// into dot‑separated keys, and returns a map:
-  ///   { 'en': {'home.title', 'home.subtitle', …}, 'fr': { … } }
-  /// Also handles linked translation files (those containing ':/file.json' references)
-  Future<Map<String, Set<String>>> _loadTranslations(Directory translationsDir) async {
-    final result = <String, Set<String>>{};
-    const IOFileLoader fileLoader = IOFileLoader();
-    const LinkedFileResolver linkedFileResolver = JsonLinkedFileResolver(fileLoader: fileLoader);
-
-    for (var file in translationsDir.listSync().whereType<File>()) {
-      if (!file.path.endsWith('.json')) continue;
-
-      try {
-        final local = basenameWithoutExtension(file.path);
-        final langCode = local.split('-').first;
-        final hasCountryCode = local.split('-').length > 1;
-        final countryCode = hasCountryCode ? local.split('-').last : null;
-        final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
-
-        // Process linked files if present using the shared resolver
-        final resolvedJson = await linkedFileResolver.resolveLinkedFiles(
-          basePath: translationsDir.path,
-          languageCode: langCode,
-          baseJson: jsonMap,
-          countryCode: countryCode,
-        );
-        result[local] = _flatten(resolvedJson);
-      } catch (e) {
-        stderr.writeln('Error reading ${file.path}: $e');
-      }
-    }
-    return result;
-  }
-
-  Set<String> _flatten(Map<String, dynamic> json, [String parentKey = '']) {
-    final keys = <String>{};
-    for (var entry in json.entries) {
-      final key = entry.key;
-      final value = entry.value;
-
-      final newKey = parentKey.isEmpty ? key : '$parentKey.$key';
-      if (value is String) {
-        keys.add(newKey);
-        continue;
-      }
-
-      if (value is Map<String, dynamic>) {
-        keys.addAll(_flatten(value, newKey));
-        continue;
-      }
-
-      if (value is List || value is num || value is bool) {
-        keys.add(newKey);
-      }
-    }
-    return keys;
-  }
-
-  Set<String> _scanSourceForKeys(Directory srcDir) {
-    List<RegExp> keyPatterns = [
-      // 1) tr('foo.bar') or tr("foo.bar"), with optional args/comma before the )
-      RegExp(r"""\btr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-
-      // 2) context.tr('foo.bar') same as above but with the context qualifier
-      RegExp(r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-
-      // 3) 'foo.bar'.tr() or "foo.bar".tr(), allowing whitespace/newlines
-      RegExp(r"""['"]([^'"]+)['"]\s*\.\s*tr\s*\(\s*[^)]*\)"""),
-
-      // 4) generated keys: LocaleKeys.foo_bar (whitespace around the dot ok)
-      RegExp(r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
-
-      // 5) plural() calls
-      RegExp(r"""\bplural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-
-      // 6) context.plural() calls
-      RegExp(r"""context\s*\.\s*plural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-    ];
-
-    final used = <String>{};
-
-    for (var file in srcDir.listSync(recursive: true).whereType<File>().where((f) => f.path.endsWith('.dart'))) {
-      try {
-        final content = file.readAsStringSync();
-        for (var pattern in keyPatterns) {
-          final matches = pattern.allMatches(content);
-          for (var match in matches) {
-            if (match.groupCount > 0) {
-              String key = match.group(1)!;
-              if (pattern.pattern.contains('LocaleKeys')) {
-                key = key.replaceAll('_', '.');
-              }
-              used.add(key);
-            }
-          }
-        }
-      } catch (e) {
-        stderr.writeln('Error reading ${file.path}: $e');
-      }
-    }
-
-    return used;
   }
 
   void _report(Map<String, Set<String>> allTranslations, Set<String> usedKeys) {

--- a/bin/audit/key_parser.dart
+++ b/bin/audit/key_parser.dart
@@ -89,9 +89,14 @@ class KeyParser {
         srcDir.listSync(recursive: true).whereType<File>().where((f) => f.path.endsWith('.dart')).toList();
     for (var file in files) {
       final content = file.readAsStringSync();
+
+      // remove all comments to avoid false positives
+      final commentPattern = RegExp(r'\/\/.*?$|\/\*.*?\*/', multiLine: true, dotAll: true);
+      final commentRemovedContent = content.replaceAll(commentPattern, '');
+
       for (var patternType in KeyPatternType.values) {
         final pattern = RegExp(patternType.pattern);
-        final matches = pattern.allMatches(content);
+        final matches = pattern.allMatches(commentRemovedContent);
 
         for (var match in matches) {
           if (match.groupCount > 0) {

--- a/bin/audit/key_parser.dart
+++ b/bin/audit/key_parser.dart
@@ -7,7 +7,7 @@ import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
 enum KeyPatternType {
   trFunction(pattern: r"""\btr\s*\(\s*['"]([^'"]+)['"](?:(?!gender\s*:)[^)])*\)"""),
   contextTrFunction(pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:(?!gender\s*:)[^)])*\)"""),
-  stringTrMethod(pattern: r""""([^"]+)"\s*\.tr\s*\((?:(?!gender\s*:)[^)])*\)"""),
+  stringTrMethod(pattern: r""""([^'"]+)"\s*\.tr\s*\((?:(?!gender\s*:)[^)])*\)"""),
   localeKeys(pattern: r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
   // plural
   pluralFunction(pattern: r"""\bplural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']),
@@ -19,7 +19,7 @@ enum KeyPatternType {
   contextTrFunctionWithGender(
       pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"]\s*,\s*gender\s*:\s*[^)]*\)""",
       keywords: ["male", "female"]),
-  stringTrMethodWithGender(pattern: r""""([^"]+)"\s*\.tr\s*\(\s*gender\s*:\s*[^)]*\)""", keywords: ["male", "female"]);
+  stringTrMethodWithGender(pattern: r""""([^'"]+)"\s*\.tr\s*\(\s*gender\s*:\s*[^)]*\)""", keywords: ["male", "female"]);
 
   const KeyPatternType({required this.pattern, this.keywords = const []});
 

--- a/bin/audit/key_parser.dart
+++ b/bin/audit/key_parser.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:easy_localization/src/linked_file_resolver.dart';
+import 'package:path/path.dart';
+import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
+
+enum KeyPatternType {
+  trFunction(pattern: r"""\btr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
+  contextTrFunction(pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
+  stringTrMethod(pattern: r"""['"]([^'"]+)['"]\s*\.\s*tr\s*\(\s*[^)]*\)"""),
+  localeKeys(pattern: r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
+  pluralFunction(pattern: r"""\bplural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']),
+  contextPluralFunction(
+      pattern: r"""context\s*\.\s*plural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']);
+
+  const KeyPatternType({required this.pattern, this.keywords = const []});
+
+  final String pattern;
+  final List<String> keywords;
+}
+
+class KeyParser {
+  /// Walks [translationsDir], reads every `.json`, flattens nested maps
+  /// into dot‑separated keys, and returns a map:
+  ///   { 'en': {'home.title', 'home.subtitle', …}, 'fr': { … } }
+  /// Also handles linked translation files (those containing ':/file.json' references)
+  Future<Map<String, Set<String>>> parseKeysInTranslationsDir(Directory translationsDir) async {
+    final result = <String, Set<String>>{};
+    const IOFileLoader fileLoader = IOFileLoader();
+    const LinkedFileResolver linkedFileResolver = JsonLinkedFileResolver(fileLoader: fileLoader);
+
+    for (var file in translationsDir.listSync().whereType<File>()) {
+      if (!file.path.endsWith('.json')) continue;
+
+      final local = basenameWithoutExtension(file.path);
+      final langCode = local.split('-').first;
+      final hasCountryCode = local.split('-').length > 1;
+      final countryCode = hasCountryCode ? local.split('-').last : null;
+      final jsonMap = json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+
+      // Process linked files if present using the shared resolver
+      final resolvedJson = await linkedFileResolver.resolveLinkedFiles(
+        basePath: translationsDir.path,
+        languageCode: langCode,
+        baseJson: jsonMap,
+        countryCode: countryCode,
+      );
+      result[local] = _flatten(resolvedJson);
+    }
+    return result;
+  }
+
+  Set<String> _flatten(Map<String, dynamic> json, [String parentKey = '']) {
+    final keys = <String>{};
+    for (var entry in json.entries) {
+      final key = entry.key;
+      final value = entry.value;
+
+      final newKey = parentKey.isEmpty ? key : '$parentKey.$key';
+      if (value is String) {
+        keys.add(newKey);
+        continue;
+      }
+
+      if (value is Map<String, dynamic>) {
+        keys.addAll(_flatten(value, newKey));
+        continue;
+      }
+
+      if (value is List || value is num || value is bool) {
+        keys.add(newKey);
+      }
+    }
+    return keys;
+  }
+
+  Set<String> parseKeysInSourceDir(Directory srcDir) {
+    final used = <String>{};
+
+    List<File> files =
+        srcDir.listSync(recursive: true).whereType<File>().where((f) => f.path.endsWith('.dart')).toList();
+    for (var file in files) {
+      final content = file.readAsStringSync();
+      for (var patternType in KeyPatternType.values) {
+        final pattern = RegExp(patternType.pattern);
+        final matches = pattern.allMatches(content);
+
+        for (var match in matches) {
+          if (match.groupCount > 0) {
+            String key = match.group(1)!;
+            if (pattern.pattern.contains('LocaleKeys')) {
+              key = key.replaceAll('_', '.');
+            }
+
+            if (patternType.keywords.isNotEmpty) {
+              for (var keyword in patternType.keywords) {
+                key += '.$keyword';
+                used.add(key);
+              }
+
+              continue;
+            }
+
+            used.add(key);
+          }
+        }
+      }
+    }
+
+    return used;
+  }
+}

--- a/bin/audit/key_parser.dart
+++ b/bin/audit/key_parser.dart
@@ -91,7 +91,12 @@ class KeyParser {
       final content = file.readAsStringSync();
 
       // remove all comments to avoid false positives
-      final commentPattern = RegExp(r'\/\/.*?$|\/\*.*?\*/', multiLine: true, dotAll: true);
+      // remove single-line comments that start the line (optionally preceded by whitespace)
+      // and multi-line /* ... */ blocks
+      final commentPattern = RegExp(
+        r'^[ \t]*//.*?$|/\*[\s\S]*?\*/',
+        multiLine: true,
+      );
       final commentRemovedContent = content.replaceAll(commentPattern, '');
 
       for (var patternType in KeyPatternType.values) {

--- a/bin/audit/key_parser.dart
+++ b/bin/audit/key_parser.dart
@@ -5,13 +5,21 @@ import 'package:path/path.dart';
 import 'package:easy_localization/src/file_loaders/io_file_loader.dart';
 
 enum KeyPatternType {
-  trFunction(pattern: r"""\btr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-  contextTrFunction(pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)"""),
-  stringTrMethod(pattern: r"""['"]([^'"]+)['"]\s*\.\s*tr\s*\(\s*[^)]*\)"""),
+  trFunction(pattern: r"""\btr\s*\(\s*['"]([^'"]+)['"](?:(?!gender\s*:)[^)])*\)"""),
+  contextTrFunction(pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"](?:(?!gender\s*:)[^)])*\)"""),
+  stringTrMethod(pattern: r""""([^"]+)"\s*\.tr\s*\((?:(?!gender\s*:)[^)])*\)"""),
   localeKeys(pattern: r"""LocaleKeys\s*\.\s*([A-Za-z0-9_]+)"""),
+  // plural
   pluralFunction(pattern: r"""\bplural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']),
   contextPluralFunction(
-      pattern: r"""context\s*\.\s*plural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']);
+      pattern: r"""context\s*\.\s*plural\s*\(\s*['"]([^'"]+)['"](?:\s*,[^)]*)?\)""", keywords: ['other']),
+  // gender
+  trFunctionWithGender(
+      pattern: r"""\btr\s*\(\s*['"]([^'"]+)['"]\s*,\s*gender\s*:\s*[^)]*\)""", keywords: ["male", "female"]),
+  contextTrFunctionWithGender(
+      pattern: r"""context\s*\.\s*tr\s*\(\s*['"]([^'"]+)['"]\s*,\s*gender\s*:\s*[^)]*\)""",
+      keywords: ["male", "female"]),
+  stringTrMethodWithGender(pattern: r""""([^"]+)"\s*\.tr\s*\(\s*gender\s*:\s*[^)]*\)""", keywords: ["male", "female"]);
 
   const KeyPatternType({required this.pattern, this.keywords = const []});
 
@@ -94,8 +102,8 @@ class KeyParser {
 
             if (patternType.keywords.isNotEmpty) {
               for (var keyword in patternType.keywords) {
-                key += '.$keyword';
-                used.add(key);
+                String keyWithKeyword = '$key.$keyword';
+                used.add(keyWithKeyword);
               }
 
               continue;

--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/aissat/easy_localization/issues
 version: 3.0.9
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Following the issues : https://github.com/aissat/easy_localization/issues/766, i've updated the audit command to return a non zero exit code (1) if there is missing keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Audit docs reorganized: heading changes, added Arguments and Errors tables, and expanded Logger guidance (customization, filters, disabling, and custom printers).

* **New Features**
  * Improved audit key parsing to more reliably detect translation keys in source and translation files.
  * New CLI flag to show warnings for missing keys.

* **Bug Fixes**
  * Audit command now exits non‑zero when non‑variable missing translation keys are found.

* **Chores**
  * Raised minimum Dart SDK requirement.

* **Examples**
  * Added iOS LLDB helper and import for example debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->