### PR TITLE
fix: prevent double rebuild on initial translation load

### DIFF
--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -323,7 +323,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   Future<Localization> load(Locale value) async {
     EasyLocalization.logger.debug('Load Localization Delegate');
     if (localizationController!.translations == null) {
-      await localizationController!.loadTranslations(false);
+      await localizationController!.loadTranslations();
     }
 
     Localization.load(

--- a/lib/src/easy_localization_app.dart
+++ b/lib/src/easy_localization_app.dart
@@ -323,7 +323,7 @@ class _EasyLocalizationDelegate extends LocalizationsDelegate<Localization> {
   Future<Localization> load(Locale value) async {
     EasyLocalization.logger.debug('Load Localization Delegate');
     if (localizationController!.translations == null) {
-      await localizationController!.loadTranslations();
+      await localizationController!.loadTranslations(false);
     }
 
     Localization.load(

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -103,7 +103,7 @@ class EasyLocalizationController extends ChangeNotifier {
     }
   }
 
-  Future loadTranslations() async {
+  Future loadTranslations([bool notify = true]) async {
     Map<String, dynamic> data;
     try {
       data = Map.from(await loadTranslationData(_locale));
@@ -124,7 +124,7 @@ class EasyLocalizationController extends ChangeNotifier {
         }
         _fallbackTranslations = Translations(data);
       }
-      notifyListeners();
+      if (notify) notifyListeners();
     } on FlutterError catch (e) {
       onLoadError(e);
     } catch (e) {

--- a/lib/src/easy_localization_controller.dart
+++ b/lib/src/easy_localization_controller.dart
@@ -103,7 +103,7 @@ class EasyLocalizationController extends ChangeNotifier {
     }
   }
 
-  Future loadTranslations([bool notify = true]) async {
+  Future loadTranslations() async {
     Map<String, dynamic> data;
     try {
       data = Map.from(await loadTranslationData(_locale));
@@ -124,7 +124,6 @@ class EasyLocalizationController extends ChangeNotifier {
         }
         _fallbackTranslations = Translations(data);
       }
-      if (notify) notifyListeners();
     } on FlutterError catch (e) {
       onLoadError(e);
     } catch (e) {


### PR DESCRIPTION
## Problem

When `setLocale()` is called, `notifyListeners()` fires **twice**:

1. Inside `loadTranslations()` — added by commit c336ee11 to notify dependents when translations are first loaded
2. Explicitly in `setLocale()` itself — the original notification for locale changes

This causes every widget depending on `EasyLocalization` context (e.g. `MaterialApp`, `context.locale`, `context.localizationDelegates`) to **rebuild twice on every locale change**.

## Root cause

`loadTranslations()` calls `notifyListeners()` unconditionally. But every call site already has a `notifyListeners()` following it:

| Call site | `notifyListeners()` after? |
|---|---|
| `setLocale()` | ✅ Yes — line 194 |

Since `setLocale()` always calls `notifyListeners()` after `loadTranslations()` completes, the one inside `loadTranslations()` is fully redundant and only causes the double rebuild.

For the initial load path (`_EasyLocalizationDelegate.load()`), Flutter's own `Localizations` widget already handles rebuilding its subtree when the `Future<Localization>` returned by `load()` resolves — no explicit `notifyListeners()` is needed there.

## Fix

Remove `notifyListeners()` from inside `loadTranslations()`. The single `notifyListeners()` in `setLocale()` is sufficient and correct for all locale-change notifications.

**No parameter changes. No new logic. One line removed.**

```dart
// Before — double notification on every locale change
Future loadTranslations() async {
  // ... load data ...
  notifyListeners(); // ← redundant, setLocale() already calls this
}

Future<void> setLocale(Locale l) async {
  _locale = l;
  await loadTranslations(); // fires notifyListeners() (1)
  notifyListeners();        // fires notifyListeners() (2) ← wasted rebuild
  ...
}

// After — single notification, clean
Future loadTranslations() async {
  // ... load data ...
  // no notifyListeners() here
}

Future<void> setLocale(Locale l) async {
  _locale = l;
  await loadTranslations();
  notifyListeners(); // ← single, correct notification
  ...
}
```

**Result:** widgets depending on `EasyLocalization` rebuild exactly once per locale change. Initial load and all existing behaviour are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted notification behavior when loading fallback translations to prevent unnecessary interface updates during the translation loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->