### PR TITLE
Re-export public_ext from generated LocaleKeys file

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -177,6 +177,8 @@ Future _writeKeys(StringBuffer classBuilder, List<FileSystemEntity> files,
 
 // ignore_for_file: constant_identifier_names
 
+export 'package:easy_localization/src/public_ext.dart';
+
 abstract class LocaleKeys {
 ''';
 


### PR DESCRIPTION
Closes #780.

Adds `export 'package:easy_localization/src/public_ext.dart';` to the generated file's header. Consumers that already import the generated `locale_keys.g.dart` (e.g. `import 'generated/locale_keys.g.dart';`) now also pick up the `Text.tr()` / `Text.plural()` extensions without a second `import 'package:easy_localization/easy_localization.dart';` line — eliminating the two-import requirement called out in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated localization modules now automatically export localization utilities and extensions, providing developers with direct and simplified access to essential localization features without requiring manual imports throughout their projects.
  * This enhancement streamlines the localization workflow, reduces boilerplate code, and significantly improves the overall developer experience when building multilingual and internationalized applications across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->